### PR TITLE
mask password in log entries

### DIFF
--- a/maven-scm-providers/maven-scm-provider-hg/src/main/java/org/apache/maven/scm/provider/hg/HgUtils.java
+++ b/maven-scm-providers/maven-scm-provider-hg/src/main/java/org/apache/maven/scm/provider/hg/HgUtils.java
@@ -89,7 +89,7 @@ public final class HgUtils
             Commandline cmd = buildCmd( workingDir, cmdAndArgs );
             if ( logger.isInfoEnabled() )
             {
-                logger.info( "EXECUTING: " + cmd );
+                logger.info( "EXECUTING: " + HgUtils.cryptPassword( cmd ) );
             }
 
             //Execute command
@@ -322,5 +322,19 @@ public final class HgUtils
             }
         }
         return false;
+    }
+
+    public static String cryptPassword( Commandline cl )
+    {
+        String clString = cl.toString();
+
+        int pos = clString.indexOf( "@" );
+
+        if ( pos > 0 )
+        {
+            clString = clString.replaceAll( ":\\w+@", ":*****@" );
+        }
+
+        return clString;
     }
 }

--- a/maven-scm-providers/maven-scm-provider-hg/src/test/java/org/apache/maven/scm/provider/hg/HgUtilsTest.java
+++ b/maven-scm-providers/maven-scm-provider-hg/src/test/java/org/apache/maven/scm/provider/hg/HgUtilsTest.java
@@ -20,6 +20,8 @@ package org.apache.maven.scm.provider.hg;
  */
 
 import static org.junit.Assert.*;
+
+import org.apache.maven.scm.provider.hg.command.HgCommandConstants;
 import org.codehaus.plexus.util.cli.Commandline;
 import org.junit.Test;
 
@@ -32,5 +34,18 @@ public class HgUtilsTest
     {
         Commandline cmd = HgUtils.buildCmd( null, new String[] {} );
         assertEquals( null, cmd.getWorkingDirectory() );
+    }
+
+    @Test
+    public void testCryptPassword()
+        throws Exception
+    {
+        Commandline cmdHttps = HgUtils.buildCmd( null, new String[] {
+                HgCommandConstants.PUSH_CMD,
+                null,
+                "https://username:password@example.com/foobar"
+        } );
+        Commandline cmd = new Commandline( HgUtils.cryptPassword( cmdHttps ) );
+        assertEquals( "https://username:*****@example.com/foobar", cmd.getArguments()[3] );
     }
 }


### PR DESCRIPTION
Greetings!

The current Mercurial implementation writes the cleartext password in log entries. I've made a small patch that masks this.

Best regards,

Mads Mohr Christensen
hr.mohr@gmail.com
