### PR TITLE
Remove <server> block.

### DIFF
--- a/maven-scm-plugin/src/it/settings.xml
+++ b/maven-scm-plugin/src/it/settings.xml
@@ -21,14 +21,6 @@ under the License.
 
 <settings>
 
-  <servers>
-    <server>
-      <id>my.server</id>
-      <username>me</username>
-      <password>{iFtD2TFFjzoHEDN1RxW21zEBYW0Gt7GwbsOm6yDS63s=}</password>
-    </server>
-  </servers>
-
   <profiles>
     <profile>
       <id>it-repo</id>


### PR DESCRIPTION
Useless for this IT, and currently triggers a failure in CI.

Should help solve https://builds.apache.org/job/maven-scm/830/console failure. 
Jenkins slave seems to have a special security settings that currently makes it fail (see https://builds.apache.org/job/maven-scm/ws/maven-scm-plugin/target/it/scm-741-validate-scm-url-matches-working-copy/build.log for details).
