### PR TITLE
Add ssl support ( ie ssl:host:port://path )

### DIFF
--- a/maven-scm-providers/maven-scm-provider-perforce/src/main/java/org/apache/maven/scm/provider/perforce/repository/PerforceScmProviderRepository.java
+++ b/maven-scm-providers/maven-scm-provider-perforce/src/main/java/org/apache/maven/scm/provider/perforce/repository/PerforceScmProviderRepository.java
@@ -28,7 +28,7 @@ import org.apache.maven.scm.provider.ScmProviderRepositoryWithHost;
 public class PerforceScmProviderRepository
     extends ScmProviderRepositoryWithHost
 {
-    private boolean ssl;
+    private String protocol;//when empty perforce treats it as 'tcp'
 
     private String path;
 
@@ -46,11 +46,11 @@ public class PerforceScmProviderRepository
     }
 
 
-    public PerforceScmProviderRepository( boolean ssl, String host, int port, String path, String user, String password )
+    public PerforceScmProviderRepository( String protocol, String host, int port, String path, String user, String password )
     {
         this( host, port, path, user, password );
-        
-        this.ssl = ssl;
+
+        this.protocol = protocol;
     }
 
     // ----------------------------------------------------------------------
@@ -62,8 +62,8 @@ public class PerforceScmProviderRepository
         return path;
     }
 
-    public boolean isSsl()
+    public String getProtocol()
     {
-        return this.ssl;
+        return this.protocol;
     }
 }

--- a/maven-scm-providers/maven-scm-provider-perforce/src/test/java/org/apache/maven/scm/provider/perforce/PerforceScmProviderTest.java
+++ b/maven-scm-providers/maven-scm-provider-perforce/src/test/java/org/apache/maven/scm/provider/perforce/PerforceScmProviderTest.java
@@ -22,6 +22,7 @@ package org.apache.maven.scm.provider.perforce;
 import org.apache.maven.scm.ScmTestCase;
 import org.apache.maven.scm.provider.perforce.repository.PerforceScmProviderRepository;
 import org.apache.maven.scm.repository.ScmRepository;
+import org.codehaus.plexus.util.StringUtils;
 
 /**
  * @author <a href="mailto:trygvis@inamo.no">Trygve Laugst&oslash;l</a>
@@ -46,7 +47,7 @@ public class PerforceScmProviderTest
 
         assertEquals( "//depot/projects/pathname", p4Repo.getPath() );
 
-        assertEquals( false, p4Repo.isSsl() );
+        assertTrue( StringUtils.isBlank( p4Repo.getProtocol() ) );
     }
 
     public void testParseConnectionWithUsername()
@@ -183,6 +184,6 @@ public class PerforceScmProviderTest
 
         assertEquals( "//depot/projects/pathname", p4Repo.getPath() );
 
-        assertEquals( true, p4Repo.isSsl() );
+        assertEquals( "ssl", p4Repo.getProtocol() );
     }
 }


### PR DESCRIPTION
Please help to review this enhancement which adds ssl support for perforce provider where 'ssl:' is added to before the host section ( scm:perforce:ssl:host:port://path).  This change is backward compatible with current format ( scm:provider:host:port://path)
