### PR TITLE
[SCM-682] Maven release fails when releasing from a named branch

### DIFF
--- a/maven-scm-providers/maven-scm-provider-hg/src/main/java/org/apache/maven/scm/provider/hg/HgUtils.java
+++ b/maven-scm-providers/maven-scm-provider-hg/src/main/java/org/apache/maven/scm/provider/hg/HgUtils.java
@@ -283,6 +283,18 @@ public final class HgUtils
         {
             return branchName;
         }
+
+        /** {@inheritDoc} */
+        public void consumeLine( String line )
+        {
+            if ( getLogger().isDebugEnabled() )
+            {
+                getLogger().debug( line );
+            }
+            String trimmedLine = line.trim();
+
+            doConsume( null, trimmedLine );
+        }
     }
 
 


### PR DESCRIPTION
Applying patch suggested by Esteban Porcelli, consisting in overriding HgConsumer.consumeLine method, which removes characters when it shoudln't