### PR TITLE
SCM-765 use the correct commiter/author when commiting

### DIFF
--- a/maven-scm-providers/maven-scm-providers-git/maven-scm-provider-jgit/src/main/java/org/apache/maven/scm/provider/git/jgit/command/checkin/JGitCheckInCommand.java
+++ b/maven-scm-providers/maven-scm-providers-git/maven-scm-provider-jgit/src/main/java/org/apache/maven/scm/provider/git/jgit/command/checkin/JGitCheckInCommand.java
@@ -53,7 +53,9 @@ import java.util.Set;
  * </ol>
  * the "maven-scm" config can be configured like this: <br>
  * the default email domain to be used (will be used to create an email from the username passed to maven):<br>
- * <code>git config --global maven-scm.maildomain "mycomp.com"</code> <br>
+ * <code>git config --global maven-scm.maildomain mycomp.com</code> <br>
+ * you can also enforce the usage of the username for the author and committer:<br>
+ * <code>git config --global maven-scm.forceUsername true</code> <br>
  * 
  * @author <a href="mailto:struberg@yahoo.de">Mark Struberg</a>
  * @author Dominik Bartholdi (imod)
@@ -67,6 +69,8 @@ public class JGitCheckInCommand
     protected static final String GIT_MAVEN_SECTION = "maven-scm";
 
     protected static final String GIT_MAILDOMAIN = "maildomain";
+
+    protected static final String GIT_FORCE = "forceUsername";
 
     /**
      * {@inheritDoc}
@@ -170,10 +174,12 @@ public class JGitCheckInCommand
 
     private UserInfo getCommitter( ScmProviderRepository repo, Git git )
     {
+        boolean forceMvnUser = git.getRepository().getConfig().getBoolean( GIT_MAVEN_SECTION, GIT_FORCE, false );
+
         // git config
         UserConfig user = git.getRepository().getConfig().get( UserConfig.KEY );
         String committerName = null;
-        if ( !user.isCommitterNameImplicit() )
+        if ( !forceMvnUser && !user.isCommitterNameImplicit() )
         {
             committerName = user.getCommitterName();
         }
@@ -213,10 +219,12 @@ public class JGitCheckInCommand
 
     private UserInfo getAuthor( ScmProviderRepository repo, Git git )
     {
+        boolean forceMvnUser = git.getRepository().getConfig().getBoolean( GIT_MAVEN_SECTION, GIT_FORCE, false );
+
         // git config
         UserConfig user = git.getRepository().getConfig().get( UserConfig.KEY );
         String authorName = null;
-        if ( !user.isAuthorNameImplicit() )
+        if ( !forceMvnUser && !user.isAuthorNameImplicit() )
         {
             authorName = user.getAuthorName();
         }

--- a/maven-scm-providers/maven-scm-providers-git/maven-scm-provider-jgit/src/site/markdown/index.md.vm
+++ b/maven-scm-providers/maven-scm-providers-git/maven-scm-provider-jgit/src/site/markdown/index.md.vm
@@ -86,6 +86,10 @@ If you don't define a user in the .gitconfig, then the user passed as "username"
 the hostname to be used as the domain. you can configure a default domain in the .gitconfig as follows:   
 
 	git config --global maven-scm.maildomain mycomp.com	
+	
+You can also enforce the usage of the "username" for the author and committer (omit the default in the .gitconfig):
+	
+	git config --global maven-scm.forceUsername true
 
 
 			

--- a/maven-scm-providers/maven-scm-providers-git/maven-scm-provider-jgit/src/test/java/org/apache/maven/scm/provider/git/jgit/command/checkin/JGitCheckInCommandCommitterAuthorTckTest.java
+++ b/maven-scm-providers/maven-scm-providers-git/maven-scm-provider-jgit/src/test/java/org/apache/maven/scm/provider/git/jgit/command/checkin/JGitCheckInCommandCommitterAuthorTckTest.java
@@ -141,6 +141,26 @@ public class JGitCheckInCommandCommitterAuthorTckTest
         git = Git.open( getWorkingCopy() );
         config = git.getRepository().getConfig();
         unsetConfig( config );
+        config.setString( "user", null, "name", "dbartholdi" );
+        config.setBoolean( JGitCheckInCommand.GIT_MAVEN_SECTION, null, JGitCheckInCommand.GIT_FORCE, true );
+        config.setString( JGitCheckInCommand.GIT_MAVEN_SECTION, null, JGitCheckInCommand.GIT_MAILDOMAIN, "anycomp.com" );
+        config.save();
+
+        // make a change with an user on the commandline
+        createAndCommitFile( fooJava, "dude" );
+
+        // check new commit is done with new maven user in config
+        head = getHeadCommit( git.getRepository() );
+        assertEquals( "dude", head.getCommitterIdent().getName() );
+        assertEquals( "dude@anycomp.com", head.getCommitterIdent().getEmailAddress() );
+        assertEquals( "dude", head.getAuthorIdent().getName() );
+        assertEquals( "dude@anycomp.com", head.getAuthorIdent().getEmailAddress() );
+        JGitUtils.closeRepo( git );
+
+        // unset a user and maven user but set default mail domain
+        git = Git.open( getWorkingCopy() );
+        config = git.getRepository().getConfig();
+        unsetConfig( config );
         config.setString( JGitCheckInCommand.GIT_MAVEN_SECTION, null, JGitCheckInCommand.GIT_MAILDOMAIN, "anycomp.com" );
         config.save();
 


### PR DESCRIPTION
fix JGit provider to use the correct commiter/author when committing,

Fixes SCM-765
