### PR TITLE
SCM-764 : Fix password displayed in cl.toString()

### DIFF
--- a/maven-scm-providers/maven-scm-providers-git/maven-scm-provider-gitexe/src/main/java/org/apache/maven/scm/provider/git/gitexe/command/GitCommandLineUtils.java
+++ b/maven-scm-providers/maven-scm-providers-git/maven-scm-provider-gitexe/src/main/java/org/apache/maven/scm/provider/git/gitexe/command/GitCommandLineUtils.java
@@ -21,6 +21,7 @@ package org.apache.maven.scm.provider.git.gitexe.command;
 
 import org.apache.maven.scm.ScmException;
 import org.apache.maven.scm.log.ScmLogger;
+import org.apache.maven.scm.provider.git.gitexe.command.tag.AnonymousCommandLine;
 import org.codehaus.plexus.util.cli.CommandLineException;
 import org.codehaus.plexus.util.cli.CommandLineUtils;
 import org.codehaus.plexus.util.cli.Commandline;
@@ -90,6 +91,26 @@ public final class GitCommandLineUtils
 
         Commandline cl = new Commandline();
 
+        composeCommandLine(workingDirectory, command, cl);
+
+        return cl;
+    }
+
+    public static Commandline getAnonymousBaseGitCommandLine( File workingDirectory, String command )
+    {
+        if ( command == null || command.length() == 0 )
+        {
+            return null;
+        }
+
+        Commandline cl = new AnonymousCommandLine();
+
+        composeCommandLine(workingDirectory, command, cl);
+
+        return cl;
+    }
+
+    private static void composeCommandLine(File workingDirectory, String command, Commandline cl) {
         cl.setExecutable( "git" );
 
         cl.createArg().setValue( command );
@@ -98,8 +119,6 @@ public final class GitCommandLineUtils
         {
             cl.setWorkingDirectory( workingDirectory.getAbsolutePath() );
         }
-
-        return cl;
     }
 
     public static int execute( Commandline cl, StreamConsumer consumer, CommandLineUtils.StringStreamConsumer stderr,

--- a/maven-scm-providers/maven-scm-providers-git/maven-scm-provider-gitexe/src/main/java/org/apache/maven/scm/provider/git/gitexe/command/tag/AnonymousCommandLine.java
+++ b/maven-scm-providers/maven-scm-providers-git/maven-scm-provider-gitexe/src/main/java/org/apache/maven/scm/provider/git/gitexe/command/tag/AnonymousCommandLine.java
@@ -1,0 +1,50 @@
+package org.apache.maven.scm.provider.git.gitexe.command.tag;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import org.codehaus.plexus.util.cli.Commandline;
+
+public class AnonymousCommandLine extends Commandline 
+{
+
+    private Pattern passwordPattern = Pattern.compile("^.*:(.*)@.*$");
+
+    /**
+     * Provides an anonymous output to mask password.
+     * Considering URL of type : &lt;&lt;protocol&gt;&gt;://&lt;&lt;user&gt;&gt;:&lt;&lt;password&gt;&gt;@&lt;&lt;host_definition&gt;&gt;
+     */
+    @Override
+    public String toString() 
+    {
+        String output = super.toString();
+        final Matcher passwordMatcher = passwordPattern.matcher(output);
+        if (passwordMatcher.find()) 
+        {
+            // clear password
+            final String clearPassword = passwordMatcher.group(1);
+            // to be replaced in output by stars
+            output = output.replace(clearPassword, "********");
+        }
+        return output;
+    }
+}

--- a/maven-scm-providers/maven-scm-providers-git/maven-scm-provider-gitexe/src/main/java/org/apache/maven/scm/provider/git/gitexe/command/tag/GitTagCommand.java
+++ b/maven-scm-providers/maven-scm-providers-git/maven-scm-provider-gitexe/src/main/java/org/apache/maven/scm/provider/git/gitexe/command/tag/GitTagCommand.java
@@ -160,7 +160,7 @@ public class GitTagCommand
     public static Commandline createPushCommandLine( GitScmProviderRepository repository, ScmFileSet fileSet, String tag )
         throws ScmException
     {
-        Commandline cl = GitCommandLineUtils.getBaseGitCommandLine( fileSet.getBasedir(), "push" );
+        Commandline cl = GitCommandLineUtils.getAnonymousBaseGitCommandLine( fileSet.getBasedir(), "push" );
 
         cl.createArg().setValue( repository.getPushUrl() );
         cl.createArg().setValue( "refs/tags/" + tag );

--- a/maven-scm-providers/maven-scm-providers-git/maven-scm-provider-gitexe/src/test/java/org/apache/maven/scm/provider/git/gitexe/command/tag/GitTagCommandTest.java
+++ b/maven-scm-providers/maven-scm-providers-git/maven-scm-provider-gitexe/src/test/java/org/apache/maven/scm/provider/git/gitexe/command/tag/GitTagCommandTest.java
@@ -51,7 +51,6 @@ public class GitTagCommandTest
         messageFileString = "-F " + path;
     }
 
-
     public void testCommandLineTag()
         throws Exception
     {
@@ -63,6 +62,23 @@ public class GitTagCommandTest
     {
         testCommandLine( "scm:git:http://anonymous@foo.com/git/trunk", "my-tag-1",
                          "git tag " + messageFileString + " my-tag-1" );
+    }
+
+    public void testPushCommandLineWithUsernameAndPassword()
+        throws Exception
+    {
+        String scmUrl="scm:git:https://user:password@foo.com/git/trunk";
+        String tag ="my-tag-1";
+        ScmRepository repository = getScmManager().makeScmRepository(scmUrl);
+        GitScmProviderRepository gitRepository = (GitScmProviderRepository) repository.getProviderRepository();
+        Commandline cl = GitTagCommand.createPushCommandLine( gitRepository, getScmFileSet(), tag );
+        assertCommandLine( "git push https://user:password@foo.com/git/trunk refs/tags/my-tag-1", null, cl );
+
+        String scmUrlFakeForTest="scm:git:https://user:******@foo.com/git/trunk";
+        repository = getScmManager().makeScmRepository( scmUrlFakeForTest );
+        gitRepository = (GitScmProviderRepository) repository.getProviderRepository();
+        Commandline clFakeForTest = GitTagCommand.createPushCommandLine( gitRepository, getScmFileSet(), tag );
+        assertEquals( cl.toString(),clFakeForTest.toString() );
     }
 
     // ----------------------------------------------------------------------

--- a/maven-scm-test/src/main/java/org/apache/maven/scm/ScmTestCase.java
+++ b/maven-scm-test/src/main/java/org/apache/maven/scm/ScmTestCase.java
@@ -361,7 +361,10 @@ public abstract class ScmTestCase
         {
             cl.setWorkingDirectory( expectedWorkingDirectory.getAbsolutePath() );
         }
-        assertEquals( cl.toString(), actualCommand.toString() );
+
+        String expectedCommandLineAsExecuted = StringUtils.join( cl.getShellCommandline(), " " );
+        String actualCommandLineAsExecuted =  StringUtils.join( actualCommand.getShellCommandline(), " " );
+        assertEquals( expectedCommandLineAsExecuted, actualCommandLineAsExecuted );
     }
 
     /**


### PR DESCRIPTION
The idea is to subclass CommandLine from plexus-utils to avoid using the default toString()
