### PR TITLE
[SCM-786] Add missing dependency on junit to maven-scm-test

### DIFF
--- a/maven-scm-test/pom.xml
+++ b/maven-scm-test/pom.xml
@@ -49,6 +49,10 @@
       <version>1.3</version>
 
     </dependency>
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+    </dependency>
 
   </dependencies>
 </project>


### PR DESCRIPTION
`maven-scm-test` uses JUnit, but doesn't declare it as dependency. This works because JUnit is a transitive dependency pulled in by Plexus container. However in Plexus 1.6 scope of JUnit was changed to "provided" meaning that maven-scm-test won't work with Plexus 1.6 unless explicit dependency on JUnit is added.
