### PR TITLE
Correctly strip quotes in GitStatusConsumer

### DIFF
--- a/maven-scm-providers/maven-scm-providers-git/maven-scm-provider-gitexe/src/main/java/org/apache/maven/scm/provider/git/gitexe/command/status/GitStatusConsumer.java
+++ b/maven-scm-providers/maven-scm-providers-git/maven-scm-provider-gitexe/src/main/java/org/apache/maven/scm/provider/git/gitexe/command/status/GitStatusConsumer.java
@@ -222,12 +222,16 @@ public class GitStatusConsumer
         return targetFile.isFile();
     }
 
-    protected static String resolvePath(String fileEntry, URI path) {
+    protected static String resolvePath( String fileEntry, URI path )
+    {
         /* Quotes may be included (from the git status line) when an fileEntry includes spaces */
-        String cleanedEntry = stripQuotes(fileEntry);
-        if (path != null) {
-            return resolveURI(cleanedEntry, path).getPath();
-        } else {
+        String cleanedEntry = stripQuotes( fileEntry );
+        if ( path != null )
+        {
+            return resolveURI( cleanedEntry, path ).getPath();
+        }
+        else
+        {
             return cleanedEntry;
         }
     }
@@ -243,7 +247,7 @@ public class GitStatusConsumer
         // When using URI.create, spaces need to be escaped but not the slashes, so we can't use
         // URLEncoder.encode( String, String )
         // new File( String ).toURI() results in an absolute URI while path is relative, so that can't be used either.
-        return path.relativize(URI.create(stripQuotes(fileEntry).replace(" ", "%20")));
+        return path.relativize( URI.create( stripQuotes( fileEntry ).replace( " ", "%20" ) ) );
     }
 
 
@@ -256,8 +260,9 @@ public class GitStatusConsumer
      * @param str the (potentially quoted) string, must not be {@code null}
      * @return the string with a pair of double quotes removed (if they existed)
      */
-    private static String stripQuotes(String str) {
+    private static String stripQuotes( String str )
+    {
         int strLen = str.length();
-        return (strLen > 0 && str.startsWith("\"") && str.endsWith("\"")) ? str.substring(1, strLen - 1) : str;
+        return ( strLen > 0 && str.startsWith( "\"" ) && str.endsWith( "\"" ) ) ? str.substring( 1, strLen - 1 ) : str;
     }
 }

--- a/maven-scm-providers/maven-scm-providers-git/maven-scm-provider-gitexe/src/main/java/org/apache/maven/scm/provider/git/gitexe/command/status/GitStatusConsumer.java
+++ b/maven-scm-providers/maven-scm-providers-git/maven-scm-provider-gitexe/src/main/java/org/apache/maven/scm/provider/git/gitexe/command/status/GitStatusConsumer.java
@@ -222,15 +222,13 @@ public class GitStatusConsumer
         return targetFile.isFile();
     }
 
-    protected static String resolvePath( String fileEntry, URI path )
-    {
-        if ( path != null )
-        {
-            return resolveURI( fileEntry, path ).getPath();
-        }
-        else
-        {
-            return fileEntry;
+    protected static String resolvePath(String fileEntry, URI path) {
+        /* Quotes may be included (from the git status line) when an fileEntry includes spaces */
+        String cleanedEntry = stripQuotes(fileEntry);
+        if (path != null) {
+            return resolveURI(cleanedEntry, path).getPath();
+        } else {
+            return cleanedEntry;
         }
     }
 
@@ -245,13 +243,21 @@ public class GitStatusConsumer
         // When using URI.create, spaces need to be escaped but not the slashes, so we can't use
         // URLEncoder.encode( String, String )
         // new File( String ).toURI() results in an absolute URI while path is relative, so that can't be used either.
-        String str = fileEntry.replace( " ", "%20" );
-        return path.relativize( URI.create( str ) );
+        return path.relativize(URI.create(stripQuotes(fileEntry).replace(" ", "%20")));
     }
 
 
     public List<ScmFile> getChangedFiles()
     {
         return changedFiles;
+    }
+
+    /**
+     * @param str the (potentially quoted) string, must not be {@code null}
+     * @return the string with a pair of double quotes removed (if they existed)
+     */
+    private static String stripQuotes(String str) {
+        int strLen = str.length();
+        return (strLen > 0 && str.startsWith("\"") && str.endsWith("\"")) ? str.substring(1, strLen - 1) : str;
     }
 }

--- a/maven-scm-providers/maven-scm-providers-git/maven-scm-provider-gitexe/src/test/java/org/apache/maven/scm/provider/git/gitexe/command/status/GitStatusConsumerTest.java
+++ b/maven-scm-providers/maven-scm-providers-git/maven-scm-provider-gitexe/src/test/java/org/apache/maven/scm/provider/git/gitexe/command/status/GitStatusConsumerTest.java
@@ -353,6 +353,18 @@ public class GitStatusConsumerTest
 
         assertEquals( "pom.xml", GitStatusConsumer.resolvePath( "work with spaces/pom.xml", path ) );
         assertEquals( "work with spaces/pom.xml", GitStatusConsumer.resolvePath( "work with spaces/pom.xml", null ) );
+
+        // spaces in path with quotes
+        repositoryRoot = getTestFile( "repo" );
+        workingDirectory = getTestFile( "repo/work with spaces and quotes" );
+
+        path = repositoryRoot.toURI().relativize( workingDirectory.toURI() );
+
+        assertEquals( "work with spaces and quotes", path.getPath() );
+
+        assertEquals( "pom.xml", GitStatusConsumer.resolvePath( "\"work with spaces and quotes/pom.xml\"", path ) );
+        assertEquals( "work with spaces and quotes/pom.xml",
+                GitStatusConsumer.resolvePath( "\"work with spaces and quotes/pom.xml\"", null ) );
     }
 
 	private void testScmFile( ScmFile fileToTest, String expectedFilePath, ScmFileStatus expectedStatus )


### PR DESCRIPTION
Before this, `GitStatusConsumer.resolvePath()` and
`GitStatusConsumer.resolveURI()` got into trouble with
files that include spaces.

To reproduce failure condition (in a git repo):

    echo "I'll fail" > "some nice file"
    git add "some nice file"
    git status --porcelain

The output of the `git status` is:

    A  "some nice file"

This causes at least
[JENKINS-24686](https://issues.jenkins-ci.org/browse/JENKINS-24686)
downstream.