### PR TITLE
fix incorrect resolving of branch name from HG outgoing changes && NPE in HgUtils.differentOutgoingBranchFound

### DIFF
--- a/maven-scm-providers/maven-scm-provider-hg/src/main/java/org/apache/maven/scm/provider/hg/HgUtils.java
+++ b/maven-scm-providers/maven-scm-provider-hg/src/main/java/org/apache/maven/scm/provider/hg/HgUtils.java
@@ -297,7 +297,7 @@ public final class HgUtils
      * Method users should not stop the push on a negative return, instead, they should
      * hg push -r(branch being released)
      *
-     * @param logger            the logger
+     * @param logger            the logger31
      * @param workingDir        the working dir
      * @param workingbranchName the working branch name
      * @return true if a different outgoing branch was found

--- a/maven-scm-providers/maven-scm-provider-hg/src/main/java/org/apache/maven/scm/provider/hg/HgUtils.java
+++ b/maven-scm-providers/maven-scm-provider-hg/src/main/java/org/apache/maven/scm/provider/hg/HgUtils.java
@@ -48,6 +48,8 @@ import java.util.Map;
 public final class HgUtils
 {
 
+    public static final String DEFAULT = "default";
+
     private HgUtils()
     {
         // no op
@@ -78,7 +80,7 @@ public final class HgUtils
         List<Integer> outgoingExitCodes = new ArrayList<Integer>( 2 );
         outgoingExitCodes.add( Integer.valueOf( 0 ) ); //There are changes
         outgoingExitCodes.add( Integer.valueOf( 1 ) ); //No changes
-        EXIT_CODE_MAP.put( HgCommandConstants.OUTGOING_CMD, outgoingExitCodes );        
+        EXIT_CODE_MAP.put( HgCommandConstants.OUTGOING_CMD, outgoingExitCodes );
     }
 
     public static ScmResult execute( HgConsumer consumer, ScmLogger logger, File workingDir, String[] cmdAndArgs )
@@ -301,7 +303,7 @@ public final class HgUtils
      * @return true if a different outgoing branch was found
      * @throws ScmException on outgoing command error
      */
-    public static boolean differentOutgoingBranchFound( ScmLogger logger, File workingDir, String workingbranchName )
+    public static boolean differentOutgoingBranchFound( ScmLogger logger, File workingDir,String workingbranchName )
         throws ScmException
     {
         String[] outCmd = new String[]{ HgCommandConstants.OUTGOING_CMD };
@@ -312,16 +314,19 @@ public final class HgUtils
         {
             for ( HgChangeSet set : changes )
             {
-                if ( set.getBranch() != null )
-                {
-                    logger.warn( "A different branch than " + workingbranchName
-                        + " was found in outgoing changes, branch name was " + set.getBranch()
-                        + ". Only local branch named " + workingbranchName + " will be pushed." );
+                if (!getBranchName(workingbranchName).equals(getBranchName(set.getBranch()))) {
+                    logger.warn( "A different branch than " + getBranchName(workingbranchName)
+                        + " was found in outgoing changes, branch name was " + getBranchName(set.getBranch())
+                        + ". Only local branch named " + getBranchName(workingbranchName) + " will be pushed." );
                     return true;
                 }
             }
         }
         return false;
+    }
+
+    private static String getBranchName(String branch) {
+        return branch == null ? DEFAULT : branch;
     }
 
     public static String maskPassword( Commandline cl )

--- a/maven-scm-providers/maven-scm-provider-hg/src/main/java/org/apache/maven/scm/provider/hg/command/inventory/HgOutgoingConsumer.java
+++ b/maven-scm-providers/maven-scm-provider-hg/src/main/java/org/apache/maven/scm/provider/hg/command/inventory/HgOutgoingConsumer.java
@@ -23,6 +23,7 @@ import org.apache.maven.scm.log.ScmLogger;
 import org.apache.maven.scm.provider.hg.command.HgConsumer;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 
 /**
@@ -34,7 +35,7 @@ import java.util.List;
 public class HgOutgoingConsumer
     extends HgConsumer
 {
-    private List<HgChangeSet> changes = new ArrayList<HgChangeSet>();
+    private List<HgChangeSet> changes = Collections.synchronizedList(new ArrayList<HgChangeSet>());
 
     private static final String BRANCH = "branch";
 


### PR DESCRIPTION
Without this fix we constantly getting  incorrect warning message in logs during release about the "A different branch than...". I mean that I use a simple named branches at release, they are works but with warnings. Also once I've seen a  NPE in that block but I can't reproduce it and I have no big wish to reproduce. It is faster to fix.