### PR TITLE
[SCM-706] finer-grained handling of file rename status for gitexe provider...

### DIFF
--- a/maven-scm-api/src/main/java/org/apache/maven/scm/ScmFileStatus.java
+++ b/maven-scm-api/src/main/java/org/apache/maven/scm/ScmFileStatus.java
@@ -59,9 +59,22 @@ public final class ScmFileStatus
 
     /**
      * The file has been renamed or moved in the working tree.
+     * Used by SCM that do not indicate if the renamed path is the old or new path.
      * @since 1.7
      */
     public static final ScmFileStatus RENAMED = new ScmFileStatus( "renamed" );
+
+    /**
+     * The file has been renamed or moved in the working tree. This is the source of rename operation.
+     * @since 1.9
+     */
+    public static final ScmFileStatus RENAMED_FROM = new ScmFileStatus( "renamed-from" );
+
+    /**
+     * The file has been renamed or moved in the working tree. This is the target of rename operation.
+     * @since 1.9
+     */
+    public static final ScmFileStatus RENAMED_TO = new ScmFileStatus( "renamed-to" );
 
     /**
      * The file has been copied in the working tree.

--- a/maven-scm-providers/maven-scm-providers-git/maven-scm-provider-gitexe/src/main/java/org/apache/maven/scm/provider/git/gitexe/command/status/GitStatusCommand.java
+++ b/maven-scm-providers/maven-scm-providers-git/maven-scm-provider-gitexe/src/main/java/org/apache/maven/scm/provider/git/gitexe/command/status/GitStatusCommand.java
@@ -19,8 +19,6 @@ package org.apache.maven.scm.provider.git.gitexe.command.status;
  * under the License.
  */
 
-import java.net.URI;
-
 import org.apache.maven.scm.ScmException;
 import org.apache.maven.scm.ScmFileSet;
 import org.apache.maven.scm.command.status.AbstractStatusCommand;
@@ -32,6 +30,8 @@ import org.apache.maven.scm.provider.git.repository.GitScmProviderRepository;
 import org.codehaus.plexus.util.cli.CommandLineUtils;
 import org.codehaus.plexus.util.cli.Commandline;
 
+import java.net.URI;
+
 /**
  * @author <a href="mailto:brett@apache.org">Brett Porter</a>
  *
@@ -41,7 +41,7 @@ public class GitStatusCommand
     implements GitCommand
 {
     /** {@inheritDoc} */
-    protected StatusScmResult executeStatusCommand( ScmProviderRepository repo, ScmFileSet fileSet )
+    public StatusScmResult executeStatusCommand( ScmProviderRepository repo, ScmFileSet fileSet )
         throws ScmException
     {
         Commandline clRevparse = createRevparseShowToplevelCommand( fileSet );

--- a/maven-scm-providers/maven-scm-providers-git/maven-scm-provider-gitexe/src/test/java/org/apache/maven/scm/provider/git/gitexe/command/status/GitStatusConsumerTest.java
+++ b/maven-scm-providers/maven-scm-providers-git/maven-scm-provider-gitexe/src/test/java/org/apache/maven/scm/provider/git/gitexe/command/status/GitStatusConsumerTest.java
@@ -110,7 +110,7 @@ public class GitStatusConsumerTest
         assertEquals( "project.xml", changedFiles.get( 0 ).getPath() );
 
         changedFiles = getChangedFiles( "A  \"test file with spaces and a special \\177 character.xml\"", null );
-        
+
         assertNotNull( changedFiles );
         assertEquals( 1, changedFiles.size() );
         assertEquals("test file with spaces and a special \u007f character.xml", changedFiles.get( 0 ).getPath() );
@@ -123,7 +123,7 @@ public class GitStatusConsumerTest
         assertNotNull( changedFiles );
         assertEquals( 1, changedFiles.size() );
         testScmFile( changedFiles.get( 0 ), "project.xml", ScmFileStatus.ADDED );
-        
+
         changedFiles = getChangedFiles( "AM \"test file with spaces and a special \\177 character.xml\"", null );
 
         assertNotNull( changedFiles );
@@ -353,7 +353,7 @@ public class GitStatusConsumerTest
         assertNotNull( changedFiles );
         assertEquals( 1, changedFiles.size() );
         assertEquals( "test file with spaces and a special \u007f character.xml", changedFiles.get( 0 ).getPath() );
-        
+
         FileUtils.deleteDirectory( dir );
     }
 
@@ -391,8 +391,8 @@ public class GitStatusConsumerTest
 
         assertNotNull( changedFiles );
         assertEquals( 2, changedFiles.size() );
-        assertEquals( "OldCapfile", changedFiles.get(0).getPath() );
-        assertEquals( "NewCapFile", changedFiles.get(1).getPath() );
+        testScmFile( changedFiles.get( 0 ), "OldCapfile", ScmFileStatus.RENAMED_FROM );
+        testScmFile( changedFiles.get( 1 ), "NewCapFile", ScmFileStatus.RENAMED_TO );
 
         tmpFile = new File( dir, "New test file with spaces and a special \u007f character.xml" );
 


### PR DESCRIPTION
..., rename source is not added to the set of files for commit operation anymore

This is an actualisation of the original Darryl L. Miles's patch from [SCM-706](https://issues.apache.org/jira/browse/SCM-706).
All tests for gitexe provider are passing locally.
I've also confirmed locally that it fixes the `release-with-pom` behaviour in `maven-release-plugin` under git.
