### PR TITLE
Change: Added consumeProcessOutput() to stop hang.

### DIFF
--- a/maven-scm-plugin/src/it/scm-741-validate-scm-url-matches-working-copy/prepare.groovy
+++ b/maven-scm-plugin/src/it/scm-741-validate-scm-url-matches-working-copy/prepare.groovy
@@ -21,6 +21,8 @@
 // BUT we actually don't store that special versioning directory as-is to prevent potentially confusing 
 // (to say the least) a svn checkout of the maven-scm project.
 // 
+
+println "prepare.groovy:"
 File dotSvnDir = new File( basedir, 'dotSvnDir' )
 assert dotSvnDir.exists()
 assert dotSvnDir.isDirectory()
@@ -28,6 +30,7 @@ assert dotSvnDir.renameTo( new File( basedir, '.svn' ) )
 
 println "svn --version"
 def proc = "svn --version".execute()
+proc.consumeProcessOutput()
 proc.waitFor()
 println "return code: ${ proc.exitValue()}"
 println "stderr: ${proc.err.text}"
@@ -35,6 +38,7 @@ println "stdout: ${proc.in.text}"
 
 println "svn upgrade $basedir"
 proc = ["svn", "upgrade", "$basedir"].execute()
+proc.consumeProcessOutput()
 proc.waitFor()
 println "return code: ${ proc.exitValue()}"
 println "stderr: ${proc.err.text}"


### PR DESCRIPTION
This is a simple fix to stop the build from hanging when executing "svn --version".