### PR TITLE
Move System.println(..) to Logger.debug(..) in SVN changelog consumer

### DIFF
--- a/maven-scm-providers/maven-scm-providers-svn/maven-scm-provider-svnexe/src/main/java/org/apache/maven/scm/provider/svn/svnexe/command/changelog/SvnChangeLogConsumer.java
+++ b/maven-scm-providers/maven-scm-providers-svn/maven-scm-provider-svnexe/src/main/java/org/apache/maven/scm/provider/svn/svnexe/command/changelog/SvnChangeLogConsumer.java
@@ -282,7 +282,10 @@ public class SvnChangeLogConsumer
             {
                 action = ScmFileStatus.UNKNOWN;
             }
-            System.out.println( actionStr + " : " + name );
+            if ( getLogger().isDebugEnabled() )
+            {
+                getLogger().debug( actionStr + " : " + name );
+            }
             final ChangeFile changeFile = new ChangeFile( name, currentRevision );
             changeFile.setAction( action );
             changeFile.setOriginalName( originalName );


### PR DESCRIPTION
When this provider is used internally, this consumer produce heavy logs in System.out without using logger.
This PR replaces "System.println" instead by "Logger.debug"