### PR TITLE
added recursive support with submodule clone

### DIFF
--- a/maven-scm-providers/maven-scm-providers-git/maven-scm-provider-gitexe/src/main/java/org/apache/maven/scm/provider/git/gitexe/command/checkout/GitCheckOutCommand.java
+++ b/maven-scm-providers/maven-scm-providers-git/maven-scm-provider-gitexe/src/main/java/org/apache/maven/scm/provider/git/gitexe/command/checkout/GitCheckOutCommand.java
@@ -126,6 +126,24 @@ public class GitCheckOutCommand
             lastCommandLine = clCheckout.toString();
         }
 
+        if ( recursive )
+        {
+            // and now lets pull down the submodules
+            Commandline clSubmodule = GitCommandLineUtils.getBaseGitCommandLine(
+                  fileSet.getBasedir(), "submodule" );
+            clSubmodule.createArg().setValue( "update" );
+            clSubmodule.createArg().setValue( "--init" );
+            clSubmodule.createArg().setValue( "--recursive" );
+            clSubmodule.createArg().setValue( "--remote" );
+            exitCode = GitCommandLineUtils.execute( clSubmodule, stdout, stderr, getLogger() ) ;
+            if ( exitCode != 0 )
+            {
+                return new CheckOutScmResult( clSubmodule.toString(), "The git-submodule command failed.",
+                      stderr.getOutput(), false );
+            }
+            lastCommandLine = clSubmodule.toString();
+        }
+
         // and now search for the files
         GitListConsumer listConsumer =
             new GitListConsumer( getLogger(), fileSet.getBasedir(), ScmFileStatus.CHECKED_IN );


### PR DESCRIPTION
If checkout performed with `recursive=true` then also clone submodules.  I did this mainly to be able to  use the maven-release-plugin on an aggregator project with git submodules.  Instead of all in single git repo.  This will property clone the repo with submodules during the `release:perform` goal.
