### PR TITLE
Fix "command line too long" bug in big 'gh-pages' repositories on Github

### DIFF
--- a/maven-scm-providers/maven-scm-providers-git/maven-scm-provider-gitexe/src/main/java/org/apache/maven/scm/provider/git/gitexe/command/add/GitAddCommand.java
+++ b/maven-scm-providers/maven-scm-providers-git/maven-scm-provider-gitexe/src/main/java/org/apache/maven/scm/provider/git/gitexe/command/add/GitAddCommand.java
@@ -152,7 +152,8 @@ public class GitAddCommand
         List<File> files = fileSet.getFileList();
 
         // command line can be too long for windows so add files individually (see SCM-697)
-        if ( Os.isFamily( Os.FAMILY_WINDOWS ) )
+        // sometimes it can be too long for Linux too! (when using gh-pages on Github for instance)
+        if ( Os.isFamily( Os.FAMILY_WINDOWS ) || true )
         {
             for ( File file : files )
             {

--- a/maven-scm-providers/maven-scm-providers-git/maven-scm-provider-gitexe/src/main/java/org/apache/maven/scm/provider/git/gitexe/command/add/GitAddCommand.java
+++ b/maven-scm-providers/maven-scm-providers-git/maven-scm-provider-gitexe/src/main/java/org/apache/maven/scm/provider/git/gitexe/command/add/GitAddCommand.java
@@ -63,6 +63,11 @@ public class GitAddCommand
             throw new ScmException( "You must provide at least one file/directory to add" );
         }
 
+        File workingDirectory = fileSet.getBasedir();
+        String workingDirectoryPath = workingDirectory.getAbsolutePath();
+        workingDirectoryPath = workingDirectoryPath.substring(workingDirectoryPath.lastIndexOf(".checkout/") + 1);
+        System.out.println(workingDirectoryPath);
+
         AddScmResult result = executeAddFileSet( fileSet );
 
         if ( result != null )


### PR DESCRIPTION
This pull request is aimed at launching a discussion on the following issue.

SCM-697 introduced a fix for Windows platform when command line got too long for adding files.

While the limit on Windows is low and much higher on *nix, it can be reached when using Github 'gh-pages' branch to upload Maven site documentation.

Rather than switching to individual add commands on Windows, it would be better to add a Maven parameter to switch between the two methods.