### PR TITLE
Upadate StartteamTagCommand.java

### DIFF
--- a/maven-scm-providers/maven-scm-provider-starteam/src/main/java/org/apache/maven/scm/provider/starteam/command/tag/StarteamTagCommand.java
+++ b/maven-scm-providers/maven-scm-provider-starteam/src/main/java/org/apache/maven/scm/provider/starteam/command/tag/StarteamTagCommand.java
@@ -58,7 +58,7 @@ public class StarteamTagCommand
                                            ScmTagParameters scmTagParameters )
         throws ScmException
     {
-        if ( fileSet.getFileList().isEmpty() )
+        if ( !fileSet.getFileList().isEmpty() )
         {
             throw new ScmException( "This provider doesn't support tagging subsets of a directory" );
         }


### PR DESCRIPTION
Update to fix bug around tagging by inverting the logic around empty fileset. Same change as has been made to the svn provider.
