### PR TITLE
SCM-714 fix git commit when command line got too long

### DIFF
--- a/maven-scm-providers/maven-scm-providers-git/maven-scm-provider-gitexe/src/main/java/org/apache/maven/scm/provider/git/gitexe/command/GitCommandLineUtils.java
+++ b/maven-scm-providers/maven-scm-providers-git/maven-scm-provider-gitexe/src/main/java/org/apache/maven/scm/provider/git/gitexe/command/GitCommandLineUtils.java
@@ -29,6 +29,7 @@ import org.codehaus.plexus.util.cli.StreamConsumer;
 import java.io.File;
 import java.io.IOException;
 import java.util.List;
+import java.util.Set;
 
 /**
  * Command line construction utility.
@@ -78,6 +79,29 @@ public final class GitCommandLineUtils
         {
             throw new IllegalArgumentException( "Could not get canonical paths for workingDirectory = "
                 + workingDirectory + " or files=" + files, ex );
+        }
+    }
+    
+    /**
+     * 
+     * @param cl
+     * @param files
+     */
+    public static void addTargetPattern( Commandline cl, List<File> files ) 
+    {
+        if ( files == null || files.isEmpty() ) 
+        {
+            return;
+        }
+        Set<String> fileToAdd = new java.util.HashSet<String>();
+
+        for ( File file : files ) 
+        {
+            fileToAdd.add( file.getName() );
+        }
+        for ( String patternFile : fileToAdd ) 
+        {
+            cl.createArg().setValue( "*" + patternFile );
         }
     }
 

--- a/maven-scm-providers/maven-scm-providers-git/maven-scm-provider-gitexe/src/main/java/org/apache/maven/scm/provider/git/gitexe/command/add/GitAddCommand.java
+++ b/maven-scm-providers/maven-scm-providers-git/maven-scm-provider-gitexe/src/main/java/org/apache/maven/scm/provider/git/gitexe/command/add/GitAddCommand.java
@@ -19,6 +19,12 @@ package org.apache.maven.scm.provider.git.gitexe.command.add;
  * under the License.
  */
 
+import java.io.File;
+import java.net.URI;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
 import org.apache.commons.io.FilenameUtils;
 import org.apache.maven.scm.ScmException;
 import org.apache.maven.scm.ScmFile;
@@ -35,12 +41,6 @@ import org.apache.maven.scm.provider.git.repository.GitScmProviderRepository;
 import org.codehaus.plexus.util.Os;
 import org.codehaus.plexus.util.cli.CommandLineUtils;
 import org.codehaus.plexus.util.cli.Commandline;
-
-import java.io.File;
-import java.net.URI;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
 
 /**
  * @author <a href="mailto:struberg@yahoo.de">Mark Struberg</a>
@@ -139,12 +139,11 @@ public class GitAddCommand
 
         // use this separator to make clear that the following parameters are files and not revision info.
         cl.createArg().setValue( "--" );
-
-        GitCommandLineUtils.addTarget( cl, files );
+        GitCommandLineUtils.addTargetPattern( cl, files );
 
         return cl;
     }
-
+    
     private AddScmResult executeAddFileSet( ScmFileSet fileSet )
         throws ScmException
     {

--- a/maven-scm-providers/maven-scm-providers-git/maven-scm-provider-gitexe/src/main/java/org/apache/maven/scm/provider/git/gitexe/command/checkin/GitCheckInCommand.java
+++ b/maven-scm-providers/maven-scm-providers-git/maven-scm-provider-gitexe/src/main/java/org/apache/maven/scm/provider/git/gitexe/command/checkin/GitCheckInCommand.java
@@ -251,7 +251,7 @@ public class GitCheckInCommand
         else
         {
             // specify exactly which files to commit
-            GitCommandLineUtils.addTarget( cl, fileSet.getFileList() );
+            GitCommandLineUtils.addTargetPattern( cl, fileSet.getFileList() );
         }
 
         if ( GitUtil.getSettings().isCommitNoVerify() )


### PR DESCRIPTION
SCM-714 replace commit command individual files (ex: "pom.xml") to commit command using a pattern (ex: "*pom.xml").
