### PR TITLE
Fix for Windows by changing literal newlines to backslash followed by n.

### DIFF
--- a/maven-scm-providers/maven-scm-provider-hg/src/main/java/org/apache/maven/scm/provider/hg/command/HgCommandConstants.java
+++ b/maven-scm-providers/maven-scm-provider-hg/src/main/java/org/apache/maven/scm/provider/hg/command/HgCommandConstants.java
@@ -164,7 +164,6 @@ public final class HgCommandConstants
      * verbose format for log command.
      */
     public static final String TEMPLATE_FORMAT =
-        "changeset:   {rev}:{node|short}\nbranch:      {branch}\nuser:        {author}\ndate:        {date|isodatesec}"
-            + "\ntag:         {tags}\nfiles:       {files}\ndescription:\n{desc}\n";
-
+        "changeset:   {rev}:{node|short}\\nbranch:      {branch}\\nuser:        {author}\\n" 
+            + "date:        {date|isodatesec}\\ntag:         {tags}\\nfiles:       {files}\\ndescription:\\n{desc}\\n";
 }


### PR DESCRIPTION
In the hg provider, the command to hg is being sent through cmd.exe on Windows.  The cmd.exe truncates the command parameter to hg at the newline character.  However, Mercurial (all the way back to the 0.9.2 version that you claim to support) has the ability to translate \n in its template string to newline in the output.  So I'm changing all \n in the Java source to \n.
