### PR TITLE
#resolves SCM-817 by encoding password before replace

### DIFF
--- a/maven-scm-providers/maven-scm-providers-git/maven-scm-provider-jgit/src/main/java/org/apache/maven/scm/provider/git/jgit/command/JGitUtils.java
+++ b/maven-scm-providers/maven-scm-providers-git/maven-scm-provider-jgit/src/main/java/org/apache/maven/scm/provider/git/jgit/command/JGitUtils.java
@@ -62,7 +62,9 @@ import org.eclipse.jgit.util.io.DisabledOutputStream;
 
 import java.io.File;
 import java.io.IOException;
+import java.io.UnsupportedEncodingException;
 import java.net.URI;
+import java.net.URLEncoder;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Date;
@@ -131,6 +133,17 @@ public class JGitUtils
         // make sure we do not log any passwords to the output
         String password =
             StringUtils.isNotBlank( repository.getPassword() ) ? repository.getPassword().trim() : "no-pwd-defined";
+        // if password contains special characters it won't match below.
+        // Try encoding before match. (Passwords without will be unaffected)
+        try
+        {
+            password = URLEncoder.encode( password, "UTF-8" );
+        }
+        catch ( UnsupportedEncodingException e )
+        {
+            // UTF-8 should be valid
+            e.printStackTrace();
+        }
         logger.info( "fetch url: " + repository.getFetchUrl().replace( password, "******" ) );
         logger.info( "push url: " + repository.getPushUrl().replace( password, "******" ) );
         return getCredentials( repository );


### PR DESCRIPTION
This resolves https://issues.apache.org/jira/browse/SCM-817 by encoding the password before trying to match against the pre-encoded URL.

Before this commit any passwords with special characters would print the encoded value.
```
[INFO] Change the default 'git' provider implementation to 'jgit'.
[INFO] fetch url: eddie:secr%24t@https//git.somesite.com/repo.git
[INFO] push url: eddie:secr%24t@https//git.somesite.com/repo.git
```

After this commit all passwords will be masked.
```
[INFO] Change the default 'git' provider implementation to 'jgit'.
[INFO] fetch url: eddie:******@https//git.somesite.com/repo.git
[INFO] push url: eddie:******@https//git.somesite.com/repo.git
```

I could not find any tests related specifically to security or masking, if there are tests I can expand please provide direction!