### PR TITLE
Resolves critical security bug SCM-811

### DIFF
--- a/maven-scm-api/src/main/java/org/apache/maven/scm/ScmResult.java
+++ b/maven-scm-api/src/main/java/org/apache/maven/scm/ScmResult.java
@@ -20,6 +20,8 @@ package org.apache.maven.scm;
  */
 
 import java.io.Serializable;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 /**
  * @author <a href="mailto:trygvis@inamo.no">Trygve Laugst&oslash;l</a>
@@ -38,6 +40,12 @@ public class ScmResult
 
     private final String commandLine;
 
+
+    public static final String PASSWORD_PLACE_HOLDER = "********";
+
+    //works for SVN and git
+    private Pattern patternForUserColonPasswordAtHost = Pattern.compile( "^.*:(.*)@.*$" );
+
     /**
      * Copy constructor.
      * <p/>
@@ -52,10 +60,11 @@ public class ScmResult
 
         this.providerMessage = scmResult.providerMessage;
 
-        this.commandOutput = scmResult.commandOutput;
+        this.commandOutput = masked( scmResult.commandOutput );
 
         this.success = scmResult.success;
     }
+
 
     /**
      * ScmResult contructor.
@@ -71,7 +80,7 @@ public class ScmResult
 
         this.providerMessage = providerMessage;
 
-        this.commandOutput = commandOutput;
+        this.commandOutput = masked( commandOutput );
 
         this.success = success;
     }
@@ -108,5 +117,22 @@ public class ScmResult
     public String getCommandLine()
     {
         return commandLine;
+    }
+
+
+    private String masked( String commandOutput )
+    {
+        if ( null != commandOutput )
+        {
+            final Matcher passwordMatcher = patternForUserColonPasswordAtHost.matcher( commandOutput );
+            if ( passwordMatcher.find() )
+            {
+                // clear password
+                final String clearPassword = passwordMatcher.group( 1 );
+                // to be replaced in output by stars
+                commandOutput = commandOutput.replace( clearPassword, PASSWORD_PLACE_HOLDER );
+            }
+        }
+        return commandOutput;
     }
 }

--- a/maven-scm-api/src/test/java/org/apache/maven/scm/ScmResultTest.java
+++ b/maven-scm-api/src/test/java/org/apache/maven/scm/ScmResultTest.java
@@ -1,0 +1,47 @@
+package org.apache.maven.scm;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import junit.framework.TestCase;
+import org.apache.maven.scm.provider.ScmUrlUtils;
+
+/**
+ * @author <a href="mailto:dennisl@apache.org">Dennis Lundberg</a>
+ *
+ */
+public class ScmResultTest
+    extends TestCase
+{
+
+    private static final String PASSWORD = "secr$t";
+
+    private static final String SCM_URL_GIT_COLON = "scm:git:https://username:" + PASSWORD + "@github.com/username/repo.git";
+
+    private static final String MOCK_ERROR_OUTPUT = "fatal repository " + SCM_URL_GIT_COLON + "does not exist";
+
+    public void testPasswordsAreMaskedInOutput()
+        throws Exception
+    {
+        ScmResult result = new ScmResult( "git push", "git-push failed", MOCK_ERROR_OUTPUT, false );
+        assertNotSame( "Command Output contains password", MOCK_ERROR_OUTPUT, result.getCommandOutput() );
+        assertTrue( "Command Output not masked", result.getCommandOutput().contains( ScmResult.PASSWORD_PLACE_HOLDER ) );
+    }
+
+}

--- a/maven-scm-api/src/test/java/org/apache/maven/scm/ScmResultTest.java
+++ b/maven-scm-api/src/test/java/org/apache/maven/scm/ScmResultTest.java
@@ -22,10 +22,6 @@ package org.apache.maven.scm;
 import junit.framework.TestCase;
 import org.apache.maven.scm.provider.ScmUrlUtils;
 
-/**
- * @author <a href="mailto:dennisl@apache.org">Dennis Lundberg</a>
- *
- */
 public class ScmResultTest
     extends TestCase
 {


### PR DESCRIPTION
This PR addresses https://issues.apache.org/jira/browse/SCM-811 by allowing the shared ScmResult in the api module to mask known patterns.  Covers SVN and git patterns (which are the ones impacting us and likely most popular).

Includes simple unit test to validate passwords aren't leaked.