### PR TITLE
support @ in username of scm url

### DIFF
--- a/maven-scm-providers/maven-scm-providers-git/maven-scm-provider-git-commons/src/main/java/org/apache/maven/scm/provider/git/repository/GitScmProviderRepository.java
+++ b/maven-scm-providers/maven-scm-providers-git/maven-scm-provider-git-commons/src/main/java/org/apache/maven/scm/provider/git/repository/GitScmProviderRepository.java
@@ -24,6 +24,7 @@ import org.apache.maven.scm.provider.ScmProviderRepository;
 import org.apache.maven.scm.provider.ScmProviderRepositoryWithHost;
 
 import java.io.UnsupportedEncodingException;
+import java.net.URLDecoder;
 import java.net.URLEncoder;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -381,7 +382,7 @@ public class GitScmProviderRepository
         throws ScmException
     {
         // extract user information
-        int indexAt = url.indexOf( '@' );
+        int indexAt = url.lastIndexOf( '@' );
         if ( indexAt >= 0 )
         {
             String userInfo = url.substring( 0, indexAt );

--- a/maven-scm-providers/maven-scm-providers-git/maven-scm-provider-git-commons/src/test/java/org/apache/maven/scm/provider/git/repository/GitScmProviderRepositoryTest.java
+++ b/maven-scm-providers/maven-scm-providers-git/maven-scm-provider-git-commons/src/test/java/org/apache/maven/scm/provider/git/repository/GitScmProviderRepositoryTest.java
@@ -198,6 +198,8 @@ public class GitScmProviderRepositoryTest
         testUrl( "scm:git:http://username@gitrepos.apache.org:8800/pmgt/trunk",
                  null, "http://username@gitrepos.apache.org:8800/pmgt/trunk",
                  null, "username", null, "gitrepos.apache.org", 8800, null);
+        
+
 
         testUrl( "scm:git:https://username@gitrepos.apache.org:20443/pmgt/trunk",
                  null, "https://username@gitrepos.apache.org:20443/pmgt/trunk",
@@ -214,6 +216,14 @@ public class GitScmProviderRepositoryTest
         testUrl( "scm:git:ssh://username:password@gitrepos.apache.org/pmgt/trunk",
                  null, "ssh://username:password@gitrepos.apache.org/pmgt/trunk", 
                  null, "username", "password", "gitrepos.apache.org", 0, null);
+        
+    }
+    
+    public void testUsernameWithAtAndPasswordInUrl() throws ScmRepositoryException, Exception{
+        testUrl( "scm:git:http://username@site.com:password@gitrepos.apache.org:8800/pmgt/trunk",
+            null, "http://username%40site.com:password@gitrepos.apache.org:8800/pmgt/trunk",
+            null, "username@site.com", "password", "gitrepos.apache.org", 8800, null);
+
     }
 
     // ----------------------------------------------------------------------


### PR DESCRIPTION
a url like https://username@site.com:password@github.com/repository.git was not supported.  The username and host where not derived correctly in this case.
