### PR TITLE
SCM-797: Workaround for Windows command line length limitation

### DIFF
--- a/maven-scm-providers/maven-scm-providers-git/maven-scm-provider-gitexe/src/main/java/org/apache/maven/scm/provider/git/gitexe/command/FakeShell.java
+++ b/maven-scm-providers/maven-scm-providers-git/maven-scm-provider-gitexe/src/main/java/org/apache/maven/scm/provider/git/gitexe/command/FakeShell.java
@@ -1,0 +1,72 @@
+package org.apache.maven.scm.provider.git.gitexe.command;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.codehaus.plexus.util.StringUtils;
+import org.codehaus.plexus.util.cli.shell.Shell;
+
+/**
+ * Dummy implementation of {@link Shell} that invokes the executable directly to
+ * avoid the command line length limitation on Windows.
+ * <p>
+ * The original idea was proposed in PLXUTILS-107. This implementation is
+ * adapted from
+ * https://github.com/gwt-maven-plugin/gwt-maven-plugin/blob/master/src/main/
+ * java/org/codehaus/mojo/gwt/shell/JavaShell.java
+ * </p>
+ * 
+ * @since 1.9.5
+ */
+public class FakeShell extends Shell
+{
+    @Override
+    protected List<String> getRawCommandLine( String executable, String[] arguments )
+    {
+        List<String> commandLine = new ArrayList<String>( arguments.length + 1 );
+
+        assert executable != null;
+        commandLine.add( executable );
+
+        if ( isQuotedArgumentsEnabled() )
+        {
+            char argumentQuoteDelimiter = getArgumentQuoteDelimiter();
+            char[] escapeChars = getEscapeChars( isSingleQuotedExecutableEscaped(),
+                    isDoubleQuotedExecutableEscaped() );
+            char[] quotingTriggerChars = getQuotingTriggerChars();
+            for ( String argument : arguments )
+            {
+                commandLine.add( StringUtils.quoteAndEscape( argument, argumentQuoteDelimiter, escapeChars,
+                        quotingTriggerChars, '\\', false ) );
+            }
+        }
+        else
+        {
+            for ( String argument : arguments )
+            {
+                commandLine.add( argument );
+            }
+        }
+
+        return commandLine;
+    }
+}

--- a/maven-scm-providers/maven-scm-providers-git/maven-scm-provider-gitexe/src/main/java/org/apache/maven/scm/provider/git/gitexe/command/GitCommandLineUtils.java
+++ b/maven-scm-providers/maven-scm-providers-git/maven-scm-provider-gitexe/src/main/java/org/apache/maven/scm/provider/git/gitexe/command/GitCommandLineUtils.java
@@ -21,6 +21,7 @@ package org.apache.maven.scm.provider.git.gitexe.command;
 
 import org.apache.maven.scm.ScmException;
 import org.apache.maven.scm.log.ScmLogger;
+import org.codehaus.plexus.util.Os;
 import org.codehaus.plexus.util.cli.CommandLineException;
 import org.codehaus.plexus.util.cli.CommandLineUtils;
 import org.codehaus.plexus.util.cli.Commandline;
@@ -108,6 +109,11 @@ public final class GitCommandLineUtils
         }
 
         Commandline cl = new AnonymousCommandLine();
+
+        if ( Os.isFamily( Os.FAMILY_WINDOWS ) )
+        {
+            cl.setShell( new FakeShell() );
+        }
 
         composeCommand( workingDirectory, command, cl );
 

--- a/maven-scm-providers/maven-scm-providers-git/maven-scm-provider-gitexe/src/test/java/org/apache/maven/scm/provider/git/gitexe/GitExeTestCase.java
+++ b/maven-scm-providers/maven-scm-providers-git/maven-scm-provider-gitexe/src/test/java/org/apache/maven/scm/provider/git/gitexe/GitExeTestCase.java
@@ -1,0 +1,47 @@
+package org.apache.maven.scm.provider.git.gitexe;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import java.io.File;
+import java.io.IOException;
+
+import org.apache.maven.scm.ScmTestCase;
+import org.apache.maven.scm.provider.git.gitexe.command.FakeShell;
+import org.codehaus.plexus.util.Os;
+import org.codehaus.plexus.util.StringUtils;
+import org.codehaus.plexus.util.cli.Commandline;
+
+public abstract class GitExeTestCase extends ScmTestCase {
+	@Override
+	public void assertCommandLine(String expectedCommand, File expectedWorkingDirectory, Commandline actualCommand)
+			throws IOException {
+        Commandline cl = new Commandline( expectedCommand );
+        if ( Os.isFamily( Os.FAMILY_WINDOWS ) ) {
+            cl.setShell( new FakeShell() );
+        }
+        if ( expectedWorkingDirectory != null )
+        {
+            cl.setWorkingDirectory( expectedWorkingDirectory.getAbsolutePath() );
+        }
+        String expectedCommandLineAsExecuted = StringUtils.join( cl.getShellCommandline(), " " );
+        String actualCommandLineAsExecuted = StringUtils.join( actualCommand.getShellCommandline(), " " );
+        assertEquals( expectedCommandLineAsExecuted, actualCommandLineAsExecuted );
+	}
+}

--- a/maven-scm-providers/maven-scm-providers-git/maven-scm-provider-gitexe/src/test/java/org/apache/maven/scm/provider/git/gitexe/command/add/GitExeAddCommandTest.java
+++ b/maven-scm-providers/maven-scm-providers-git/maven-scm-provider-gitexe/src/test/java/org/apache/maven/scm/provider/git/gitexe/command/add/GitExeAddCommandTest.java
@@ -4,7 +4,7 @@ import java.io.File;
 import java.util.ArrayList;
 import java.util.List;
 
-import org.apache.maven.scm.ScmTestCase;
+import org.apache.maven.scm.provider.git.gitexe.GitExeTestCase;
 import org.codehaus.plexus.util.cli.Commandline;
 
 /*
@@ -33,7 +33,7 @@ import org.codehaus.plexus.util.cli.Commandline;
  *
  */
 public class GitExeAddCommandTest 
-    extends ScmTestCase 
+    extends GitExeTestCase
 {
     
     public void testAddCommandSingleFile() throws Exception

--- a/maven-scm-providers/maven-scm-providers-git/maven-scm-provider-gitexe/src/test/java/org/apache/maven/scm/provider/git/gitexe/command/changelog/GitChangeLogCommandTest.java
+++ b/maven-scm-providers/maven-scm-providers-git/maven-scm-provider-gitexe/src/test/java/org/apache/maven/scm/provider/git/gitexe/command/changelog/GitChangeLogCommandTest.java
@@ -21,8 +21,8 @@ package org.apache.maven.scm.provider.git.gitexe.command.changelog;
 
 import org.apache.maven.scm.ScmBranch;
 import org.apache.maven.scm.ScmRevision;
-import org.apache.maven.scm.ScmTestCase;
 import org.apache.maven.scm.ScmVersion;
+import org.apache.maven.scm.provider.git.gitexe.GitExeTestCase;
 import org.apache.maven.scm.provider.git.repository.GitScmProviderRepository;
 import org.apache.maven.scm.repository.ScmRepository;
 import org.codehaus.plexus.util.StringUtils;
@@ -37,7 +37,7 @@ import java.util.Date;
  *
  */
 public class GitChangeLogCommandTest
-    extends ScmTestCase
+    extends GitExeTestCase
 {
     private File workingDirectory;
     

--- a/maven-scm-providers/maven-scm-providers-git/maven-scm-provider-gitexe/src/test/java/org/apache/maven/scm/provider/git/gitexe/command/checkin/GitCheckInCommandNoBranchTest.java
+++ b/maven-scm-providers/maven-scm-providers-git/maven-scm-provider-gitexe/src/test/java/org/apache/maven/scm/provider/git/gitexe/command/checkin/GitCheckInCommandNoBranchTest.java
@@ -25,6 +25,7 @@ import org.apache.maven.scm.ScmVersion;
 import org.apache.maven.scm.command.add.AddScmResult;
 import org.apache.maven.scm.command.checkin.CheckInScmResult;
 import org.apache.maven.scm.command.checkout.CheckOutScmResult;
+import org.apache.maven.scm.provider.git.gitexe.GitExeTestCase;
 import org.apache.maven.scm.repository.ScmRepository;
 import org.codehaus.plexus.util.FileUtils;
 
@@ -34,7 +35,7 @@ import java.io.File;
  * @author Bertrand Paquet
  */
 public class GitCheckInCommandNoBranchTest
-    extends ScmTestCase
+    extends GitExeTestCase
 {
 
     private File workingDirectory;

--- a/maven-scm-providers/maven-scm-providers-git/maven-scm-provider-gitexe/src/test/java/org/apache/maven/scm/provider/git/gitexe/command/checkin/GitCheckInCommandTest.java
+++ b/maven-scm-providers/maven-scm-providers-git/maven-scm-provider-gitexe/src/test/java/org/apache/maven/scm/provider/git/gitexe/command/checkin/GitCheckInCommandTest.java
@@ -27,6 +27,7 @@ import org.apache.maven.scm.command.checkin.CheckInScmResult;
 import org.apache.maven.scm.command.checkout.CheckOutScmResult;
 import org.apache.maven.scm.command.remove.RemoveScmResult;
 import org.apache.maven.scm.provider.git.GitScmTestUtils;
+import org.apache.maven.scm.provider.git.gitexe.GitExeTestCase;
 import org.apache.maven.scm.provider.git.repository.GitScmProviderRepository;
 import org.apache.maven.scm.provider.git.util.GitUtil;
 import org.apache.maven.scm.repository.ScmRepository;
@@ -39,7 +40,7 @@ import java.io.File;
  * @author <a href="mailto:trygvis@inamo.no">Trygve Laugst&oslash;l</a>
  */
 public class GitCheckInCommandTest
-    extends ScmTestCase
+    extends GitExeTestCase
 {
     private File messageFile;
 

--- a/maven-scm-providers/maven-scm-providers-git/maven-scm-provider-gitexe/src/test/java/org/apache/maven/scm/provider/git/gitexe/command/checkout/GitCheckOutCommandTest.java
+++ b/maven-scm-providers/maven-scm-providers-git/maven-scm-provider-gitexe/src/test/java/org/apache/maven/scm/provider/git/gitexe/command/checkout/GitCheckOutCommandTest.java
@@ -20,8 +20,8 @@ package org.apache.maven.scm.provider.git.gitexe.command.checkout;
  */
 
 import org.apache.maven.scm.ScmRevision;
-import org.apache.maven.scm.ScmTestCase;
 import org.apache.maven.scm.manager.ScmManager;
+import org.apache.maven.scm.provider.git.gitexe.GitExeTestCase;
 import org.apache.maven.scm.provider.git.repository.GitScmProviderRepository;
 import org.apache.maven.scm.repository.ScmRepository;
 import org.codehaus.plexus.util.cli.Commandline;
@@ -33,7 +33,7 @@ import java.io.File;
  *
  */
 public class GitCheckOutCommandTest
-    extends ScmTestCase
+    extends GitExeTestCase
 {
     private File workingDirectory;
 

--- a/maven-scm-providers/maven-scm-providers-git/maven-scm-provider-gitexe/src/test/java/org/apache/maven/scm/provider/git/gitexe/command/checkout/GitExeCheckOutCommandNoBranchTest.java
+++ b/maven-scm-providers/maven-scm-providers-git/maven-scm-provider-gitexe/src/test/java/org/apache/maven/scm/provider/git/gitexe/command/checkout/GitExeCheckOutCommandNoBranchTest.java
@@ -23,6 +23,7 @@ import org.apache.maven.scm.ScmFileSet;
 import org.apache.maven.scm.ScmTestCase;
 import org.apache.maven.scm.ScmVersion;
 import org.apache.maven.scm.command.checkout.CheckOutScmResult;
+import org.apache.maven.scm.provider.git.gitexe.GitExeTestCase;
 import org.apache.maven.scm.repository.ScmRepository;
 import org.codehaus.plexus.util.FileUtils;
 import org.codehaus.plexus.util.Os;
@@ -34,7 +35,7 @@ import java.io.File;
  *
  */
 public class GitExeCheckOutCommandNoBranchTest
-    extends ScmTestCase
+    extends GitExeTestCase
 {
     private File workingDirectory;
 

--- a/maven-scm-providers/maven-scm-providers-git/maven-scm-provider-gitexe/src/test/java/org/apache/maven/scm/provider/git/gitexe/command/info/GitInfoCommandTckTest.java
+++ b/maven-scm-providers/maven-scm-providers-git/maven-scm-provider-gitexe/src/test/java/org/apache/maven/scm/provider/git/gitexe/command/info/GitInfoCommandTckTest.java
@@ -22,11 +22,11 @@ package org.apache.maven.scm.provider.git.gitexe.command.info;
 import org.apache.maven.scm.CommandParameter;
 import org.apache.maven.scm.CommandParameters;
 import org.apache.maven.scm.ScmFileSet;
-import org.apache.maven.scm.ScmTestCase;
 import org.apache.maven.scm.command.info.InfoScmResult;
 import org.apache.maven.scm.provider.ScmProvider;
 import org.apache.maven.scm.provider.ScmProviderRepository;
 import org.apache.maven.scm.provider.git.GitScmTestUtils;
+import org.apache.maven.scm.provider.git.gitexe.GitExeTestCase;
 import org.codehaus.plexus.PlexusTestCase;
 import org.codehaus.plexus.util.FileUtils;
 
@@ -36,7 +36,7 @@ import java.io.File;
  * @author Olivier Lamy
  */
 public class GitInfoCommandTckTest
-    extends ScmTestCase
+    extends GitExeTestCase
 {
 
     public void testInfoCommand()

--- a/maven-scm-providers/maven-scm-providers-git/maven-scm-provider-gitexe/src/test/java/org/apache/maven/scm/provider/git/gitexe/command/remove/GitRemoveCommandTest.java
+++ b/maven-scm-providers/maven-scm-providers-git/maven-scm-provider-gitexe/src/test/java/org/apache/maven/scm/provider/git/gitexe/command/remove/GitRemoveCommandTest.java
@@ -19,7 +19,7 @@ package org.apache.maven.scm.provider.git.gitexe.command.remove;
  * under the License.
  */
 
-import org.apache.maven.scm.ScmTestCase;
+import org.apache.maven.scm.provider.git.gitexe.GitExeTestCase;
 import org.codehaus.plexus.util.FileUtils;
 import org.codehaus.plexus.util.cli.Commandline;
 
@@ -31,7 +31,7 @@ import java.util.Arrays;
  * @author <a href="mailto:struberg@yahoo.de">Mark Struberg</a>
  */
 public class GitRemoveCommandTest
-    extends ScmTestCase
+    extends GitExeTestCase
 {
 
     public void testCommandRemoveWithFile()

--- a/maven-scm-providers/maven-scm-providers-git/maven-scm-provider-gitexe/src/test/java/org/apache/maven/scm/provider/git/gitexe/command/tag/GitTagCommandTest.java
+++ b/maven-scm-providers/maven-scm-providers-git/maven-scm-provider-gitexe/src/test/java/org/apache/maven/scm/provider/git/gitexe/command/tag/GitTagCommandTest.java
@@ -19,7 +19,7 @@ package org.apache.maven.scm.provider.git.gitexe.command.tag;
  * under the License.
  */
 
-import org.apache.maven.scm.ScmTestCase;
+import org.apache.maven.scm.provider.git.gitexe.GitExeTestCase;
 import org.apache.maven.scm.provider.git.repository.GitScmProviderRepository;
 import org.apache.maven.scm.repository.ScmRepository;
 import org.codehaus.plexus.util.cli.Commandline;
@@ -30,7 +30,7 @@ import java.io.File;
  * @author <a href="mailto:struberg@yahoo.de">Mark Struberg</a>
  */
 public class GitTagCommandTest
-    extends ScmTestCase
+    extends GitExeTestCase
 {
     private File messageFile;
 

--- a/maven-scm-providers/maven-scm-providers-git/maven-scm-provider-gitexe/src/test/java/org/apache/maven/scm/provider/git/gitexe/command/update/GitUpdateCommandTest.java
+++ b/maven-scm-providers/maven-scm-providers-git/maven-scm-provider-gitexe/src/test/java/org/apache/maven/scm/provider/git/gitexe/command/update/GitUpdateCommandTest.java
@@ -20,8 +20,8 @@ package org.apache.maven.scm.provider.git.gitexe.command.update;
  */
 
 import org.apache.maven.scm.ScmBranch;
-import org.apache.maven.scm.ScmTestCase;
 import org.apache.maven.scm.ScmVersion;
+import org.apache.maven.scm.provider.git.gitexe.GitExeTestCase;
 import org.apache.maven.scm.provider.git.repository.GitScmProviderRepository;
 import org.apache.maven.scm.repository.ScmRepository;
 import org.codehaus.plexus.util.cli.Commandline;
@@ -33,7 +33,7 @@ import java.io.File;
  *
  */
 public class GitUpdateCommandTest
-    extends ScmTestCase
+    extends GitExeTestCase
 {
     public void testCommandLineNoBranch()
         throws Exception


### PR DESCRIPTION
As suggested by PLXUTILS-107 and implemented by gwt-maven-plugin, it is
possible to avoid the Windows command line length limitation by invoking
the executable directly instead of via a shell. This commit adapts the
gwt-maven-plugin implementation to supply a fake Shell in Windows
environments in order to invoke the Git executable directly.
