### PR TITLE
[SCM-832]  maven-scm-provider-jgit should support SSH public key auth

### DIFF
--- a/maven-scm-providers/maven-scm-providers-git/maven-scm-provider-jgit/src/main/java/org/apache/maven/scm/provider/git/jgit/command/JGitTransportConfigCallback.java
+++ b/maven-scm-providers/maven-scm-providers-git/maven-scm-provider-jgit/src/main/java/org/apache/maven/scm/provider/git/jgit/command/JGitTransportConfigCallback.java
@@ -22,6 +22,7 @@ package org.apache.maven.scm.provider.git.jgit.command;
 import com.jcraft.jsch.JSch;
 import com.jcraft.jsch.JSchException;
 import com.jcraft.jsch.Session;
+import org.apache.maven.scm.log.ScmLogger;
 import org.apache.maven.scm.provider.git.repository.GitScmProviderRepository;
 import org.eclipse.jgit.api.TransportConfigCallback;
 import org.eclipse.jgit.transport.*;
@@ -35,13 +36,13 @@ import org.eclipse.jgit.util.StringUtils;
 public class JGitTransportConfigCallback implements TransportConfigCallback {
     private SshSessionFactory sshSessionFactory = null;
 
-    public JGitTransportConfigCallback(GitScmProviderRepository repo) {
-        // File
-        // File + Passphrase
+    public JGitTransportConfigCallback(GitScmProviderRepository repo, ScmLogger logger) {
         if (repo.getFetchInfo().getProtocol().equals("ssh")) {
             if (!StringUtils.isEmptyOrNull(repo.getPrivateKey()) && repo.getPassphrase() == null) {
+                logger.debug("using private key with passphrase: " + repo.getPrivateKey());
                 sshSessionFactory = new UnprotectedPrivateKeySessionFactory(repo);
             } else if (!StringUtils.isEmptyOrNull(repo.getPrivateKey()) && repo.getPassphrase() != null) {
+                logger.debug("using private key: " + repo.getPrivateKey());
                 sshSessionFactory = new ProtectedPrivateKeyFileSessionFactory(repo);
             } else {
                 sshSessionFactory = new SimpleSessionFactory();

--- a/maven-scm-providers/maven-scm-providers-git/maven-scm-provider-jgit/src/main/java/org/apache/maven/scm/provider/git/jgit/command/JGitTransportConfigCallback.java
+++ b/maven-scm-providers/maven-scm-providers-git/maven-scm-provider-jgit/src/main/java/org/apache/maven/scm/provider/git/jgit/command/JGitTransportConfigCallback.java
@@ -1,0 +1,105 @@
+package org.apache.maven.scm.provider.git.jgit.command;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import com.jcraft.jsch.JSch;
+import com.jcraft.jsch.JSchException;
+import com.jcraft.jsch.Session;
+import org.apache.maven.scm.provider.git.repository.GitScmProviderRepository;
+import org.eclipse.jgit.api.TransportConfigCallback;
+import org.eclipse.jgit.transport.*;
+import org.eclipse.jgit.util.FS;
+import org.eclipse.jgit.util.StringUtils;
+
+/**
+ * Implementation of {@link TransportConfigCallback} which adds
+ * a public/private key identity to ssh URLs if configured.
+ */
+public class JGitTransportConfigCallback implements TransportConfigCallback {
+    private SshSessionFactory sshSessionFactory = null;
+
+    public JGitTransportConfigCallback(GitScmProviderRepository repo) {
+        // File
+        // File + Passphrase
+        if (repo.getFetchInfo().getProtocol().equals("ssh")) {
+            if (!StringUtils.isEmptyOrNull(repo.getPrivateKey()) && repo.getPassphrase() == null) {
+                sshSessionFactory = new UnprotectedPrivateKeySessionFactory(repo);
+            } else if (!StringUtils.isEmptyOrNull(repo.getPrivateKey()) && repo.getPassphrase() != null) {
+                sshSessionFactory = new ProtectedPrivateKeyFileSessionFactory(repo);
+            } else {
+                sshSessionFactory = new SimpleSessionFactory();
+            }
+        }
+    }
+
+    @Override
+    public void configure(Transport transport) {
+        if (transport instanceof SshTransport) {
+            SshTransport sshTransport = (SshTransport) transport;
+            sshTransport.setSshSessionFactory(sshSessionFactory);
+        }
+    }
+
+    static private class SimpleSessionFactory extends JschConfigSessionFactory {
+        @Override
+        protected void configure(OpenSshConfig.Host host, Session session) {
+        }
+    }
+
+    static private abstract class PrivateKeySessionFactory extends SimpleSessionFactory {
+        private final GitScmProviderRepository repo;
+
+        public GitScmProviderRepository getRepo() {
+            return repo;
+        }
+
+        public PrivateKeySessionFactory(GitScmProviderRepository repo) {
+            this.repo = repo;
+        }
+    }
+
+    static private class UnprotectedPrivateKeySessionFactory extends PrivateKeySessionFactory {
+
+        public UnprotectedPrivateKeySessionFactory(GitScmProviderRepository repo) {
+            super(repo);
+        }
+
+        @Override
+        protected JSch createDefaultJSch(FS fs) throws JSchException {
+            JSch defaultJSch = super.createDefaultJSch(fs);
+            defaultJSch.addIdentity(getRepo().getPrivateKey());
+            return defaultJSch;
+        }
+    }
+
+    static private class ProtectedPrivateKeyFileSessionFactory extends PrivateKeySessionFactory {
+
+        public ProtectedPrivateKeyFileSessionFactory(GitScmProviderRepository repo) {
+            super(repo);
+        }
+
+        @Override
+        protected JSch createDefaultJSch(FS fs) throws JSchException {
+            JSch defaultJSch = super.createDefaultJSch(fs);
+            defaultJSch.addIdentity(getRepo().getPrivateKey(), getRepo().getPassphrase());
+            return defaultJSch;
+        }
+    }
+}

--- a/maven-scm-providers/maven-scm-providers-git/maven-scm-provider-jgit/src/main/java/org/apache/maven/scm/provider/git/jgit/command/JGitUtils.java
+++ b/maven-scm-providers/maven-scm-providers-git/maven-scm-provider-jgit/src/main/java/org/apache/maven/scm/provider/git/jgit/command/JGitUtils.java
@@ -28,6 +28,7 @@ import org.apache.maven.scm.util.FilenameUtils;
 import org.codehaus.plexus.util.StringUtils;
 import org.eclipse.jgit.api.AddCommand;
 import org.eclipse.jgit.api.Git;
+import org.eclipse.jgit.api.PushCommand;
 import org.eclipse.jgit.api.Status;
 import org.eclipse.jgit.api.errors.GitAPIException;
 import org.eclipse.jgit.api.errors.InvalidRemoteException;
@@ -83,7 +84,7 @@ import java.util.Set;
  */
 public class JGitUtils
 {
-    
+
     private JGitUtils()
     {
         // no op
@@ -178,6 +179,8 @@ public class JGitUtils
             return new UsernamePasswordCredentialsProvider( repository.getUser().trim(),
                                                             repository.getPassword().trim() );
         }
+
+
         return null;
     }
 
@@ -185,8 +188,10 @@ public class JGitUtils
         throws GitAPIException, InvalidRemoteException, TransportException
     {
         CredentialsProvider credentials = JGitUtils.prepareSession( logger, git, repo );
-        Iterable<PushResult> pushResultList =
-            git.push().setCredentialsProvider( credentials ).setRefSpecs( refSpec ).call();
+        PushCommand command = git.push().setRefSpecs(refSpec).setCredentialsProvider(credentials)
+                .setTransportConfigCallback(new JGitTransportConfigCallback(repo));
+
+        Iterable<PushResult> pushResultList = command.call();
         for ( PushResult pushResult : pushResultList )
         {
             Collection<RemoteRefUpdate> ru = pushResult.getRemoteUpdates();

--- a/maven-scm-providers/maven-scm-providers-git/maven-scm-provider-jgit/src/main/java/org/apache/maven/scm/provider/git/jgit/command/JGitUtils.java
+++ b/maven-scm-providers/maven-scm-providers-git/maven-scm-provider-jgit/src/main/java/org/apache/maven/scm/provider/git/jgit/command/JGitUtils.java
@@ -189,7 +189,7 @@ public class JGitUtils
     {
         CredentialsProvider credentials = JGitUtils.prepareSession( logger, git, repo );
         PushCommand command = git.push().setRefSpecs(refSpec).setCredentialsProvider(credentials)
-                .setTransportConfigCallback(new JGitTransportConfigCallback(repo));
+                .setTransportConfigCallback(new JGitTransportConfigCallback(repo, logger));
 
         Iterable<PushResult> pushResultList = command.call();
         for ( PushResult pushResult : pushResultList )

--- a/maven-scm-providers/maven-scm-providers-git/maven-scm-provider-jgit/src/main/java/org/apache/maven/scm/provider/git/jgit/command/checkout/JGitCheckOutCommand.java
+++ b/maven-scm-providers/maven-scm-providers-git/maven-scm-provider-jgit/src/main/java/org/apache/maven/scm/provider/git/jgit/command/checkout/JGitCheckOutCommand.java
@@ -112,7 +112,8 @@ public class JGitCheckOutCommand
 
                 command.setCredentialsProvider( credentials ).setBranch( branch ).setDirectory( fileSet.getBasedir() );
 
-                TransportConfigCallback transportConfigCallback = new JGitTransportConfigCallback((GitScmProviderRepository) repo);
+                TransportConfigCallback transportConfigCallback = new JGitTransportConfigCallback(
+                        (GitScmProviderRepository) repo, getLogger());
                 command.setTransportConfigCallback(transportConfigCallback);
 
                 command.setProgressMonitor( monitor );
@@ -134,7 +135,8 @@ public class JGitCheckOutCommand
             {
                 // git repo exists, so we must git-pull the changes
                 CredentialsProvider credentials = JGitUtils.prepareSession( getLogger(), git, repository );
-                TransportConfigCallback transportConfigCallback = new JGitTransportConfigCallback((GitScmProviderRepository) repo);
+                TransportConfigCallback transportConfigCallback = new JGitTransportConfigCallback(
+                        (GitScmProviderRepository) repo, getLogger());
 
                 if ( version != null && StringUtils.isNotEmpty( version.getName() ) && ( version instanceof ScmTag ) )
                 {

--- a/maven-scm-providers/maven-scm-providers-git/maven-scm-provider-jgit/src/main/java/org/apache/maven/scm/provider/git/jgit/command/list/JGitListCommand.java
+++ b/maven-scm-providers/maven-scm-providers-git/maven-scm-provider-jgit/src/main/java/org/apache/maven/scm/provider/git/jgit/command/list/JGitListCommand.java
@@ -63,7 +63,8 @@ public class JGitListCommand
 
             List<ScmFile> list = new ArrayList<ScmFile>();
             Collection<Ref> lsResult = git.lsRemote().setCredentialsProvider( credentials )
-                    .setTransportConfigCallback(new JGitTransportConfigCallback((GitScmProviderRepository) repo))
+                    .setTransportConfigCallback(
+                            new JGitTransportConfigCallback((GitScmProviderRepository) repo, getLogger()))
                     .call();
             for ( Ref ref : lsResult )
             {

--- a/maven-scm-providers/maven-scm-providers-git/maven-scm-provider-jgit/src/main/java/org/apache/maven/scm/provider/git/jgit/command/list/JGitListCommand.java
+++ b/maven-scm-providers/maven-scm-providers-git/maven-scm-provider-jgit/src/main/java/org/apache/maven/scm/provider/git/jgit/command/list/JGitListCommand.java
@@ -28,6 +28,7 @@ import org.apache.maven.scm.command.list.AbstractListCommand;
 import org.apache.maven.scm.command.list.ListScmResult;
 import org.apache.maven.scm.provider.ScmProviderRepository;
 import org.apache.maven.scm.provider.git.command.GitCommand;
+import org.apache.maven.scm.provider.git.jgit.command.JGitTransportConfigCallback;
 import org.apache.maven.scm.provider.git.jgit.command.JGitUtils;
 import org.apache.maven.scm.provider.git.repository.GitScmProviderRepository;
 import org.eclipse.jgit.api.Git;
@@ -61,7 +62,9 @@ public class JGitListCommand
                 JGitUtils.prepareSession( getLogger(), git, (GitScmProviderRepository) repo );
 
             List<ScmFile> list = new ArrayList<ScmFile>();
-            Collection<Ref> lsResult = git.lsRemote().setCredentialsProvider( credentials ).call();
+            Collection<Ref> lsResult = git.lsRemote().setCredentialsProvider( credentials )
+                    .setTransportConfigCallback(new JGitTransportConfigCallback((GitScmProviderRepository) repo))
+                    .call();
             for ( Ref ref : lsResult )
             {
                 getLogger().debug( ref.getObjectId().getName() + "  " + ref.getTarget().getName() );

--- a/maven-scm-providers/maven-scm-providers-git/maven-scm-provider-jgit/src/main/java/org/apache/maven/scm/provider/git/jgit/command/remoteinfo/JGitRemoteInfoCommand.java
+++ b/maven-scm-providers/maven-scm-providers-git/maven-scm-provider-jgit/src/main/java/org/apache/maven/scm/provider/git/jgit/command/remoteinfo/JGitRemoteInfoCommand.java
@@ -63,7 +63,7 @@ public class JGitRemoteInfoCommand
 
             LsRemoteCommand lsCommand =
                 git.lsRemote().setRemote( repo.getPushUrl() ).setCredentialsProvider( credentials )
-                        .setTransportConfigCallback(new JGitTransportConfigCallback(repo));
+                        .setTransportConfigCallback(new JGitTransportConfigCallback(repo, getLogger()));
 
             Map<String, String> tag = new HashMap<String, String>();
             Collection<Ref> allTags = lsCommand.setHeads( false ).setTags( true ).call();

--- a/maven-scm-providers/maven-scm-providers-git/maven-scm-provider-jgit/src/main/java/org/apache/maven/scm/provider/git/jgit/command/remoteinfo/JGitRemoteInfoCommand.java
+++ b/maven-scm-providers/maven-scm-providers-git/maven-scm-provider-jgit/src/main/java/org/apache/maven/scm/provider/git/jgit/command/remoteinfo/JGitRemoteInfoCommand.java
@@ -26,6 +26,7 @@ import org.apache.maven.scm.command.remoteinfo.AbstractRemoteInfoCommand;
 import org.apache.maven.scm.command.remoteinfo.RemoteInfoScmResult;
 import org.apache.maven.scm.provider.ScmProviderRepository;
 import org.apache.maven.scm.provider.git.command.GitCommand;
+import org.apache.maven.scm.provider.git.jgit.command.JGitTransportConfigCallback;
 import org.apache.maven.scm.provider.git.jgit.command.JGitUtils;
 import org.apache.maven.scm.provider.git.repository.GitScmProviderRepository;
 import org.eclipse.jgit.api.Git;
@@ -61,7 +62,8 @@ public class JGitRemoteInfoCommand
             CredentialsProvider credentials = JGitUtils.getCredentials( repo );
 
             LsRemoteCommand lsCommand =
-                git.lsRemote().setRemote( repo.getPushUrl() ).setCredentialsProvider( credentials );
+                git.lsRemote().setRemote( repo.getPushUrl() ).setCredentialsProvider( credentials )
+                        .setTransportConfigCallback(new JGitTransportConfigCallback(repo));
 
             Map<String, String> tag = new HashMap<String, String>();
             Collection<Ref> allTags = lsCommand.setHeads( false ).setTags( true ).call();

--- a/maven-scm-providers/maven-scm-providers-git/maven-scm-provider-jgit/src/site/markdown/index.md.vm
+++ b/maven-scm-providers/maven-scm-providers-git/maven-scm-provider-jgit/src/site/markdown/index.md.vm
@@ -20,8 +20,9 @@ under the License.
 maven-scm-provider-jgit
 ===
 
-This scm provider implementation allows the usage of git with the release and scm plugin without having to install a nativ git client. 
-This implementation uses username and password instead of a public/private keys to authenticate the requests to a remote repository like GitHub.
+This scm provider implementation allows the usage of git with the release and scm plugin without having to install a native git client.
+This implementation can use both username and password, or public/private keys to authenticate the requests to a remote
+repository like GitHub. At the moment, public/private keys are only supported for SSH access.
 
 Configuration
 ---
@@ -65,7 +66,17 @@ Usage with the `maven-scm-plugin`
 					</dependency>
 				</dependencies>
 			</plugin>
-			
+
+Public/private key configuration in settings.xml - for use with ssh URLs like ssh://git@github.com/apache/maven-scm
+
+			<servers>
+				<server>
+				    <id>git@github.com</id>
+				    <privateKey>path/to/private/key</privateKey>
+				    <passphrase>private key passphrase</passphrase>
+				</server>
+			<server>
+
 Examples
 ____
 

--- a/src/site/site.xml
+++ b/src/site/site.xml
@@ -23,22 +23,6 @@
   xsi:schemaLocation="http://maven.apache.org/DECORATION/1.0.0 http://maven.apache.org/xsd/decoration-1.0.0.xsd"
   name="Apache Maven SCM">
 
-  <skin>
-    <groupId>org.apache.maven.skins</groupId>
-    <artifactId>maven-fluido-skin</artifactId>
-    <version>1.3.0</version>
-  </skin>
-
-  <custom>
-    <fluidoSkin>
-      <topBarEnabled>true</topBarEnabled>
-      <sideBarEnabled>false</sideBarEnabled>
-      <googleSearch></googleSearch>
-      <leftColumnClass>span2</leftColumnClass>
-      <bodyColumnClass>span10</bodyColumnClass>
-    </fluidoSkin>
-  </custom>
-
   <body>
     <menu name="Maven SCM">
       <item name="Home" href="/index.html"/>


### PR DESCRIPTION
Support for public key auth for ssh transfer is added by implementing a TransportConfigCallback and adding it to the session in all JGit Commands.
