### PR TITLE
add --cached option for git rm

### DIFF
--- a/maven-scm-providers/maven-scm-providers-git/maven-scm-provider-gitexe/pom.xml
+++ b/maven-scm-providers/maven-scm-providers-git/maven-scm-provider-gitexe/pom.xml
@@ -28,10 +28,18 @@
     <version>1.9.5</version>
   </parent>
 
-  <artifactId>maven-scm-provider-gitexe</artifactId>
+  <artifactId>maven-scm-provider-gitexe-dtdream</artifactId>
 
   <name>Maven SCM Git Provider - Git Executable Impl.</name>
   <description>Executable implementation for SCM Git Provider.</description>
+
+  <distributionManagement>
+    <repository>
+      <id>dtdream</id>
+      <name>releases</name>
+      <url>http://maven.tesir.top/content/repositories/releases/</url>
+    </repository>
+  </distributionManagement>
 
   <dependencies>
     <dependency>
@@ -67,7 +75,7 @@
             <goals>
               <goal>generate-metadata</goal>
             </goals>
-          </execution>        
+          </execution>
         </executions>        
       </plugin>
     </plugins>

--- a/maven-scm-providers/maven-scm-providers-git/maven-scm-provider-gitexe/pom.xml
+++ b/maven-scm-providers/maven-scm-providers-git/maven-scm-provider-gitexe/pom.xml
@@ -28,18 +28,10 @@
     <version>1.9.5</version>
   </parent>
 
-  <artifactId>maven-scm-provider-gitexe-dtdream</artifactId>
+  <artifactId>maven-scm-provider-gitexe</artifactId>
 
   <name>Maven SCM Git Provider - Git Executable Impl.</name>
   <description>Executable implementation for SCM Git Provider.</description>
-
-  <distributionManagement>
-    <repository>
-      <id>dtdream</id>
-      <name>releases</name>
-      <url>http://maven.tesir.top/content/repositories/releases/</url>
-    </repository>
-  </distributionManagement>
 
   <dependencies>
     <dependency>

--- a/maven-scm-providers/maven-scm-providers-git/maven-scm-provider-gitexe/src/main/java/org/apache/maven/scm/provider/git/gitexe/command/remove/GitRemoveCommand.java
+++ b/maven-scm-providers/maven-scm-providers-git/maven-scm-provider-gitexe/src/main/java/org/apache/maven/scm/provider/git/gitexe/command/remove/GitRemoveCommand.java
@@ -99,7 +99,7 @@ public class GitRemoveCommand
 
         GitCommandLineUtils.addTarget( cl, files );
 
-        cl.createArg().setValue("--cache");
+        cl.createArg().setValue("--cached");
 
         return cl;
     }

--- a/maven-scm-providers/maven-scm-providers-git/maven-scm-provider-gitexe/src/main/java/org/apache/maven/scm/provider/git/gitexe/command/remove/GitRemoveCommand.java
+++ b/maven-scm-providers/maven-scm-providers-git/maven-scm-provider-gitexe/src/main/java/org/apache/maven/scm/provider/git/gitexe/command/remove/GitRemoveCommand.java
@@ -99,6 +99,8 @@ public class GitRemoveCommand
 
         GitCommandLineUtils.addTarget( cl, files );
 
+        cl.createArg().setValue("--cache");
+
         return cl;
     }
 


### PR DESCRIPTION
For newer git release, command `git rm` will remove files definitely and it's not possible to add them back again by command `git add`. In this scenario, option `--cache` should be added to command `git rm` to prevent from physically dropping.

The only change I want to merge to `apache/maven-scm` is the `--cache` option not the `pom.xml`. Thanks a lot.
