### PR TITLE
[SCM-707] Git : spaces in username / password in URL should be encode…

### DIFF
--- a/maven-scm-providers/maven-scm-providers-git/maven-scm-provider-git-commons/src/main/java/org/apache/maven/scm/provider/git/repository/GitScmProviderRepository.java
+++ b/maven-scm-providers/maven-scm-providers-git/maven-scm-provider-git-commons/src/main/java/org/apache/maven/scm/provider/git/repository/GitScmProviderRepository.java
@@ -281,7 +281,7 @@ public class GitScmProviderRepository
             {
                 try
                 {
-                    urlSb.append( URLEncoder.encode( userName, "UTF-8" ) );
+                    urlSb.append( percentEncode( userName ) );
                 }
                 catch ( UnsupportedEncodingException e )
                 {
@@ -295,7 +295,7 @@ public class GitScmProviderRepository
                     urlSb.append( ':' );
                     try
                     {
-                        urlSb.append( URLEncoder.encode( password, "UTF-8" ) );
+                        urlSb.append( percentEncode( password ) );
                     }
                     catch ( UnsupportedEncodingException e )
                     {
@@ -320,6 +320,21 @@ public class GitScmProviderRepository
         urlSb.append( repoUrl.getPath() );
 
         return urlSb.toString();
+    }
+
+    /**
+     * Percent-encodes a string to be used in the "authority" part of an URI
+     * according to <a href="https://tools.ietf.org/html/rfc3986">RFC 3986</a>
+     *
+     * @param s the non-null String to encode
+     * @return a percent-encoded String
+     */
+    private String percentEncode( String s )
+        throws UnsupportedEncodingException
+    {
+        // URLEncoder translates into 'application/x-www-form-urlencoded'
+        // which does not percent-encodes spaces
+        return URLEncoder.encode( s, "UTF-8" ).replace("+", "%20");
     }
 
     /**

--- a/maven-scm-providers/maven-scm-providers-git/maven-scm-provider-git-commons/src/test/java/org/apache/maven/scm/provider/git/repository/GitScmProviderRepositoryTest.java
+++ b/maven-scm-providers/maven-scm-providers-git/maven-scm-provider-git-commons/src/test/java/org/apache/maven/scm/provider/git/repository/GitScmProviderRepositoryTest.java
@@ -182,12 +182,12 @@ public class GitScmProviderRepositoryTest
     public void testSpecialCharacters()
         throws Exception
     {
-        testUrl( "scm:git:http://gitrepos.apache.org", "@_&_:_?_#_%20", "password", null, "http://gitrepos.apache.org", null,
-                 "http://%40_%26_%3A_%3F_%23_%2520:password@gitrepos.apache.org", null,
+        testUrl( "scm:git:http://gitrepos.apache.org", "@_&_:_?_#_%_ ", "password", null, "http://gitrepos.apache.org", null,
+                 "http://%40_%26_%3A_%3F_%23_%25_%20:password@gitrepos.apache.org", null,
                  "gitrepos.apache.org", 0, null );
 
-        testUrl( "scm:git:http://gitrepos.apache.org", "username", "@_&_:_?_#_%20", null, "http://gitrepos.apache.org", null,
-                 "http://username:%40_%26_%3A_%3F_%23_%2520@gitrepos.apache.org", null,
+        testUrl( "scm:git:http://gitrepos.apache.org", "username", "@_&_:_?_#_%_ ", null, "http://gitrepos.apache.org", null,
+                 "http://username:%40_%26_%3A_%3F_%23_%25_%20@gitrepos.apache.org", null,
                  "gitrepos.apache.org", 0, null );
 
     }


### PR DESCRIPTION
…d as '%20' instead of '+'

[SCM-707](https://issues.apache.org/jira/browse/SCM-707) implementation for git (in b41cf6d) encodes spaces in URL using '+'. There is a unit test for special characters encoding but it failed to detect this behaviour.

I think [MRELEASE-908](https://issues.apache.org/jira/browse/MRELEASE-908) is a side effect of this wrong encoding.