### PR TITLE
[SCM-739] Use shallow clones when cloning a git repo

### DIFF
--- a/maven-scm-api/src/main/java/org/apache/maven/scm/CommandParameter.java
+++ b/maven-scm-api/src/main/java/org/apache/maven/scm/CommandParameter.java
@@ -34,6 +34,8 @@ public class CommandParameter
 
     public static final CommandParameter RECURSIVE = new CommandParameter( "recursive" );
 
+    public static final CommandParameter SHALLOW = new CommandParameter( "shallow" );
+
     public static final CommandParameter MESSAGE = new CommandParameter( "message" );
 
     public static final CommandParameter BRANCH_NAME = new CommandParameter( "branchName" );

--- a/maven-scm-api/src/main/java/org/apache/maven/scm/command/checkout/AbstractCheckOutCommand.java
+++ b/maven-scm-api/src/main/java/org/apache/maven/scm/command/checkout/AbstractCheckOutCommand.java
@@ -45,13 +45,13 @@ public abstract class AbstractCheckOutCommand
      * @param scmVersion not null
      * @return the checkout result
      * @throws ScmException if any
-     * @see #executeCheckOutCommand(ScmProviderRepository, ScmFileSet, ScmVersion, boolean)
+     * @see #executeCheckOutCommand(ScmProviderRepository, ScmFileSet, ScmVersion, boolean, boolean)
      */
     protected CheckOutScmResult executeCheckOutCommand( ScmProviderRepository repository, ScmFileSet fileSet,
                                                                  ScmVersion scmVersion )
         throws ScmException
     {
-        return executeCheckOutCommand( repository, fileSet, scmVersion, true );
+        return executeCheckOutCommand( repository, fileSet, scmVersion, true, false );
     }
 
     /**
@@ -61,12 +61,14 @@ public abstract class AbstractCheckOutCommand
      * @param fileSet not null
      * @param scmVersion not null
      * @param recursive <code>true</code> if recursive check out is wanted, <code>false</code> otherwise.
+     * @param shallow <code>true</code> if shallow check out is wanted, <code>false</code> otherwise.
      * @return the checkout result
      * @throws ScmException if any
      * @since 1.1.1
      */
     protected abstract CheckOutScmResult executeCheckOutCommand( ScmProviderRepository repository, ScmFileSet fileSet,
-                                                                 ScmVersion scmVersion, boolean recursive )
+                                                                ScmVersion scmVersion, boolean recursive,
+                                                                boolean shallow )
         throws ScmException;
 
     /** {@inheritDoc} */
@@ -75,13 +77,8 @@ public abstract class AbstractCheckOutCommand
         throws ScmException
     {
         ScmVersion scmVersion = parameters.getScmVersion( CommandParameter.SCM_VERSION, null );
-        String recursiveParam = parameters.getString( CommandParameter.RECURSIVE, null );
-        if ( recursiveParam != null )
-        {
-            boolean recursive = parameters.getBoolean( CommandParameter.RECURSIVE );
-            return executeCheckOutCommand( repository, fileSet, scmVersion, recursive );
-        }
-
-        return executeCheckOutCommand( repository, fileSet, scmVersion );
+        boolean recursive = parameters.getBoolean( CommandParameter.RECURSIVE, true );
+        boolean shallow = parameters.getBoolean( CommandParameter.SHALLOW, false );
+        return executeCheckOutCommand( repository, fileSet, scmVersion, recursive, shallow);
     }
 }

--- a/maven-scm-providers/maven-scm-provider-bazaar/src/main/java/org/apache/maven/scm/provider/bazaar/command/checkout/BazaarCheckOutCommand.java
+++ b/maven-scm-providers/maven-scm-provider-bazaar/src/main/java/org/apache/maven/scm/provider/bazaar/command/checkout/BazaarCheckOutCommand.java
@@ -48,7 +48,7 @@ public class BazaarCheckOutCommand
 {
     /** {@inheritDoc} */
     protected CheckOutScmResult executeCheckOutCommand( ScmProviderRepository repo, ScmFileSet fileSet,
-                                                        ScmVersion version, boolean recursive )
+                                                       ScmVersion version, boolean recursive, boolean shallow )
         throws ScmException
     {
         BazaarScmProviderRepository repository = (BazaarScmProviderRepository) repo;

--- a/maven-scm-providers/maven-scm-provider-clearcase/src/main/java/org/apache/maven/scm/provider/clearcase/command/checkout/ClearCaseCheckOutCommand.java
+++ b/maven-scm-providers/maven-scm-provider-clearcase/src/main/java/org/apache/maven/scm/provider/clearcase/command/checkout/ClearCaseCheckOutCommand.java
@@ -57,7 +57,7 @@ public class ClearCaseCheckOutCommand
 
     /** {@inheritDoc} */
     protected CheckOutScmResult executeCheckOutCommand( ScmProviderRepository repository, ScmFileSet fileSet,
-                                                        ScmVersion version, boolean recursive )
+                                                       ScmVersion version, boolean recursive, boolean shallow )
         throws ScmException
     {
         if ( getLogger().isDebugEnabled() )

--- a/maven-scm-providers/maven-scm-provider-hg/src/main/java/org/apache/maven/scm/provider/hg/command/checkout/HgCheckOutCommand.java
+++ b/maven-scm-providers/maven-scm-provider-hg/src/main/java/org/apache/maven/scm/provider/hg/command/checkout/HgCheckOutCommand.java
@@ -52,7 +52,7 @@ public class HgCheckOutCommand
      * {@inheritDoc}
      */
     protected CheckOutScmResult executeCheckOutCommand( ScmProviderRepository repo, ScmFileSet fileSet,
-                                                        ScmVersion scmVersion, boolean recursive )
+                                                       ScmVersion scmVersion, boolean recursive, boolean shallow )
         throws ScmException
     {
         HgScmProviderRepository repository = (HgScmProviderRepository) repo;

--- a/maven-scm-providers/maven-scm-provider-integrity/src/main/java/org/apache/maven/scm/provider/integrity/command/checkout/IntegrityCheckOutCommand.java
+++ b/maven-scm-providers/maven-scm-provider-integrity/src/main/java/org/apache/maven/scm/provider/integrity/command/checkout/IntegrityCheckOutCommand.java
@@ -60,7 +60,7 @@ public class IntegrityCheckOutCommand
      */
     @Override
     public CheckOutScmResult executeCheckOutCommand( ScmProviderRepository repository, ScmFileSet fileSet,
-                                                     ScmVersion scmVersion, boolean recursive )
+                                                    ScmVersion scmVersion, boolean recursive, boolean shallow )
         throws ScmException
     {
         CheckOutScmResult result;

--- a/maven-scm-providers/maven-scm-provider-jazz/src/main/java/org/apache/maven/scm/provider/jazz/command/checkout/JazzCheckOutCommand.java
+++ b/maven-scm-providers/maven-scm-provider-jazz/src/main/java/org/apache/maven/scm/provider/jazz/command/checkout/JazzCheckOutCommand.java
@@ -55,7 +55,7 @@ public class JazzCheckOutCommand
      * {@inheritDoc}
      */
     protected CheckOutScmResult executeCheckOutCommand( ScmProviderRepository repo, ScmFileSet fileSet,
-                                                        ScmVersion scmVersion, boolean recursive )
+                                                       ScmVersion scmVersion, boolean recursive, boolean shallow )
         throws ScmException
     {
         // TODO - Figure out how this recursive boolean impacts Jazz SCM "checkout" (load).

--- a/maven-scm-providers/maven-scm-provider-local/src/main/java/org/apache/maven/scm/provider/local/command/checkout/LocalCheckOutCommand.java
+++ b/maven-scm-providers/maven-scm-provider-local/src/main/java/org/apache/maven/scm/provider/local/command/checkout/LocalCheckOutCommand.java
@@ -47,7 +47,7 @@ public class LocalCheckOutCommand
 {
     /** {@inheritDoc} */
     protected CheckOutScmResult executeCheckOutCommand( ScmProviderRepository repo, ScmFileSet fileSet,
-                                                        ScmVersion version, boolean recursive )
+                                                       ScmVersion version, boolean recursive, boolean shallow )
         throws ScmException
     {
         LocalScmProviderRepository repository = (LocalScmProviderRepository) repo;

--- a/maven-scm-providers/maven-scm-provider-perforce/src/main/java/org/apache/maven/scm/provider/perforce/command/checkout/PerforceCheckOutCommand.java
+++ b/maven-scm-providers/maven-scm-provider-perforce/src/main/java/org/apache/maven/scm/provider/perforce/command/checkout/PerforceCheckOutCommand.java
@@ -65,7 +65,7 @@ public class PerforceCheckOutCommand
      * {@inheritDoc}
      */
     protected CheckOutScmResult executeCheckOutCommand( ScmProviderRepository repo, ScmFileSet files,
-                                                        ScmVersion version, boolean recursive )
+                                                       ScmVersion version, boolean recursive, boolean shallow )
         throws ScmException
     {
         PerforceScmProviderRepository prepo = (PerforceScmProviderRepository) repo;

--- a/maven-scm-providers/maven-scm-provider-starteam/src/main/java/org/apache/maven/scm/provider/starteam/command/checkout/StarteamCheckOutCommand.java
+++ b/maven-scm-providers/maven-scm-provider-starteam/src/main/java/org/apache/maven/scm/provider/starteam/command/checkout/StarteamCheckOutCommand.java
@@ -51,7 +51,7 @@ public class StarteamCheckOutCommand
 
     /** {@inheritDoc} */
     protected CheckOutScmResult executeCheckOutCommand( ScmProviderRepository repo, ScmFileSet fileSet,
-                                                        ScmVersion version, boolean recursive )
+                                                       ScmVersion version, boolean recursive, boolean shallow )
         throws ScmException
     {
         if ( fileSet.getFileList().size() != 0 )

--- a/maven-scm-providers/maven-scm-provider-synergy/src/main/java/org/apache/maven/scm/provider/synergy/command/checkout/SynergyCheckOutCommand.java
+++ b/maven-scm-providers/maven-scm-provider-synergy/src/main/java/org/apache/maven/scm/provider/synergy/command/checkout/SynergyCheckOutCommand.java
@@ -49,7 +49,7 @@ public class SynergyCheckOutCommand
 
     /** {@inheritDoc} */
     protected CheckOutScmResult executeCheckOutCommand( ScmProviderRepository repository, ScmFileSet fileSet,
-                                                        ScmVersion version, boolean recursive )
+                                                       ScmVersion version, boolean recursive, boolean shallow )
         throws ScmException
     {
         if ( fileSet.getFileList().size() != 0 )

--- a/maven-scm-providers/maven-scm-provider-tfs/src/main/java/org/apache/maven/scm/provider/tfs/command/TfsCheckOutCommand.java
+++ b/maven-scm-providers/maven-scm-provider-tfs/src/main/java/org/apache/maven/scm/provider/tfs/command/TfsCheckOutCommand.java
@@ -38,7 +38,7 @@ public class TfsCheckOutCommand
 {
 
     protected CheckOutScmResult executeCheckOutCommand( ScmProviderRepository r, ScmFileSet f, ScmVersion v,
-                                                        boolean recursive )
+                                                       boolean recursive, boolean shallow )
         throws ScmException
     {
         TfsScmProviderRepository tfsRepo = (TfsScmProviderRepository) r;

--- a/maven-scm-providers/maven-scm-provider-vss/src/main/java/org/apache/maven/scm/provider/vss/commands/checkout/VssCheckOutCommand.java
+++ b/maven-scm-providers/maven-scm-provider-vss/src/main/java/org/apache/maven/scm/provider/vss/commands/checkout/VssCheckOutCommand.java
@@ -41,7 +41,7 @@ public class VssCheckOutCommand
 
     /** {@inheritDoc} */
     protected CheckOutScmResult executeCheckOutCommand( ScmProviderRepository repository, ScmFileSet fileSet,
-                                                        ScmVersion version, boolean recursive )
+                                                       ScmVersion version, boolean recursive, boolean shallow )
         throws ScmException
     {
         if ( getLogger().isDebugEnabled() )

--- a/maven-scm-providers/maven-scm-providers-cvs/maven-scm-provider-cvs-commons/src/main/java/org/apache/maven/scm/provider/cvslib/command/checkout/AbstractCvsCheckOutCommand.java
+++ b/maven-scm-providers/maven-scm-providers-cvs/maven-scm-provider-cvs-commons/src/main/java/org/apache/maven/scm/provider/cvslib/command/checkout/AbstractCvsCheckOutCommand.java
@@ -45,7 +45,7 @@ public abstract class AbstractCvsCheckOutCommand
 {
     /** {@inheritDoc} */
     protected CheckOutScmResult executeCheckOutCommand( ScmProviderRepository repo, ScmFileSet fileSet,
-                                                        ScmVersion version, boolean recursive )
+                                                       ScmVersion version, boolean recursive, boolean shallow )
         throws ScmException
     {
         if ( fileSet.getBasedir().exists() )

--- a/maven-scm-providers/maven-scm-providers-git/maven-scm-provider-gitexe/src/main/java/org/apache/maven/scm/provider/git/gitexe/command/checkout/GitCheckOutCommand.java
+++ b/maven-scm-providers/maven-scm-providers-git/maven-scm-provider-gitexe/src/main/java/org/apache/maven/scm/provider/git/gitexe/command/checkout/GitCheckOutCommand.java
@@ -58,7 +58,7 @@ public class GitCheckOutCommand
      * {@inheritDoc}
      */
     protected CheckOutScmResult executeCheckOutCommand( ScmProviderRepository repo, ScmFileSet fileSet,
-                                                        ScmVersion version, boolean recursive )
+                                                       ScmVersion version, boolean recursive, boolean shallow )
         throws ScmException
     {
         GitScmProviderRepository repository = (GitScmProviderRepository) repo;
@@ -85,7 +85,7 @@ public class GitCheckOutCommand
             }
 
             // no git repo seems to exist, let's clone the original repo
-            Commandline clClone = createCloneCommand( repository, fileSet.getBasedir(), version );
+            Commandline clClone = createCloneCommand( repository, fileSet.getBasedir(), version, shallow );
 
             exitCode = GitCommandLineUtils.execute( clClone, stdout, stderr, getLogger() );
             if ( exitCode != 0 )
@@ -163,12 +163,16 @@ public class GitCheckOutCommand
      * create a git-clone repository command
      */
     private Commandline createCloneCommand( GitScmProviderRepository repository, File workingDirectory,
-                                            ScmVersion version )
+                                            ScmVersion version, boolean shallow )
     {
         Commandline cl = GitCommandLineUtils.getBaseGitCommandLine( workingDirectory.getParentFile(), "clone" );
 
-        cl.createArg().setValue( "--depth" );
-        cl.createArg().setValue( "1" );
+        if ( shallow )
+        {
+            cl.createArg().setValue( "--depth" );
+
+            cl.createArg().setValue( "1" );
+        }
 
         if ( version != null && ( version instanceof ScmBranch ) )
         {

--- a/maven-scm-providers/maven-scm-providers-git/maven-scm-provider-gitexe/src/main/java/org/apache/maven/scm/provider/git/gitexe/command/checkout/GitCheckOutCommand.java
+++ b/maven-scm-providers/maven-scm-providers-git/maven-scm-provider-gitexe/src/main/java/org/apache/maven/scm/provider/git/gitexe/command/checkout/GitCheckOutCommand.java
@@ -167,6 +167,9 @@ public class GitCheckOutCommand
     {
         Commandline cl = GitCommandLineUtils.getBaseGitCommandLine( workingDirectory.getParentFile(), "clone" );
 
+        cl.createArg().setValue( "--depth" );
+        cl.createArg().setValue( "1" );
+
         if ( version != null && ( version instanceof ScmBranch ) )
         {
 

--- a/maven-scm-providers/maven-scm-providers-git/maven-scm-provider-jgit/src/main/java/org/apache/maven/scm/provider/git/jgit/command/checkout/JGitCheckOutCommand.java
+++ b/maven-scm-providers/maven-scm-providers-git/maven-scm-provider-jgit/src/main/java/org/apache/maven/scm/provider/git/jgit/command/checkout/JGitCheckOutCommand.java
@@ -66,7 +66,7 @@ public class JGitCheckOutCommand
      * {@inheritDoc}
      */
     protected CheckOutScmResult executeCheckOutCommand( ScmProviderRepository repo, ScmFileSet fileSet,
-                                                        ScmVersion version, boolean recursive )
+                                                       ScmVersion version, boolean recursive, boolean shallow )
         throws ScmException
     {
         GitScmProviderRepository repository = (GitScmProviderRepository) repo;

--- a/maven-scm-providers/maven-scm-providers-svn/maven-scm-provider-svnexe/src/main/java/org/apache/maven/scm/provider/svn/svnexe/command/checkout/SvnCheckOutCommand.java
+++ b/maven-scm-providers/maven-scm-providers-svn/maven-scm-provider-svnexe/src/main/java/org/apache/maven/scm/provider/svn/svnexe/command/checkout/SvnCheckOutCommand.java
@@ -54,7 +54,7 @@ public class SvnCheckOutCommand
      * {@inheritDoc}
      */
     protected CheckOutScmResult executeCheckOutCommand( ScmProviderRepository repo, ScmFileSet fileSet,
-                                                        ScmVersion version, boolean recursive )
+                                                       ScmVersion version, boolean recursive, boolean shallow )
         throws ScmException
     {
         SvnScmProviderRepository repository = (SvnScmProviderRepository) repo;


### PR DESCRIPTION
For `maven-release-plugin` we don't need the whole history, but only the top commit. Using `--depth 1` allows to perform releases much faster on repositories with a long history.

Resolves https://issues.apache.org/jira/browse/SCM-739