### PR TITLE
[SCM-885] allow to use only endVersion in GitChangeLogCommand

### DIFF
--- a/maven-scm-providers/maven-scm-providers-git/maven-scm-provider-gitexe/src/main/java/org/apache/maven/scm/provider/git/gitexe/command/changelog/GitChangeLogCommand.java
+++ b/maven-scm-providers/maven-scm-providers-git/maven-scm-provider-gitexe/src/main/java/org/apache/maven/scm/provider/git/gitexe/command/changelog/GitChangeLogCommand.java
@@ -170,10 +170,10 @@ public class GitChangeLogCommand
             if ( startVersion != null )
             {
                 versionRange.append( StringUtils.escape( startVersion.getName() ) );
+				// range separator needed only if a lower bound revision is set
+                versionRange.append( ".." );
             }
 
-            versionRange.append( ".." );
-            
             if ( endVersion != null )
             {
                 versionRange.append( StringUtils.escape( endVersion.getName() ) );

--- a/maven-scm-providers/maven-scm-providers-git/maven-scm-provider-gitexe/src/test/java/org/apache/maven/scm/provider/git/gitexe/command/changelog/GitChangeLogCommandTest.java
+++ b/maven-scm-providers/maven-scm-providers-git/maven-scm-provider-gitexe/src/test/java/org/apache/maven/scm/provider/git/gitexe/command/changelog/GitChangeLogCommandTest.java
@@ -151,6 +151,14 @@ public class GitChangeLogCommandTest
                          + " -- " + StringUtils.quoteAndEscape( workingDirectory.getPath(), '"' ) );
     }
 
+    public void testCommandLineWithOnlyEndVersion()
+        throws Exception
+    {
+        testCommandLine( "scm:git:http://foo.com/git", null, null, new ScmRevision( "10" ),
+                         "git whatchanged --date=iso 10"
+                         + " -- " + StringUtils.quoteAndEscape( workingDirectory.getPath(), '"' ) );
+    }
+
     public void testCommandLineWithStartVersionAndEndVersionAndBranch()
         throws Exception
     {


### PR DESCRIPTION
On a GitChangeLogCommand setting only endVersion allows to retrieve
commits from project start until the commit corresponding to endVersion.

fixes #SCM-885

Signed-off-by: Matthieu Brouillard <matthieu@brouillard.fr>