### PR TITLE
[SCM-885] second implementation with new API

### DIFF
--- a/maven-scm-api/src/main/java/org/apache/maven/scm/CommandParameter.java
+++ b/maven-scm-api/src/main/java/org/apache/maven/scm/CommandParameter.java
@@ -50,6 +50,8 @@ public class CommandParameter
 
     public static final CommandParameter BRANCH = new CommandParameter( "branch" );
 
+    public static final CommandParameter START_FROM_ROOT = new CommandParameter( "startFromRoot" );
+
     public static final CommandParameter START_SCM_VERSION = new CommandParameter( "startScmVersion" );
 
     public static final CommandParameter END_SCM_VERSION = new CommandParameter( "endScmVersion" );

--- a/maven-scm-api/src/main/java/org/apache/maven/scm/CommandParameter.java
+++ b/maven-scm-api/src/main/java/org/apache/maven/scm/CommandParameter.java
@@ -50,7 +50,7 @@ public class CommandParameter
 
     public static final CommandParameter BRANCH = new CommandParameter( "branch" );
 
-    public static final CommandParameter START_FROM_ROOT = new CommandParameter( "startFromRoot" );
+    public static final CommandParameter FROM_START_OF_REPOSITORY = new CommandParameter( "fromStartOfRepository" );
 
     public static final CommandParameter START_SCM_VERSION = new CommandParameter( "startScmVersion" );
 

--- a/maven-scm-api/src/main/java/org/apache/maven/scm/command/changelog/AbstractChangeLogCommand.java
+++ b/maven-scm-api/src/main/java/org/apache/maven/scm/command/changelog/AbstractChangeLogCommand.java
@@ -50,7 +50,7 @@ public abstract class AbstractChangeLogCommand
     protected ChangeLogScmResult executeChangeLogCommand( ScmProviderRepository repository, ScmFileSet fileSet,
                                                           ScmVersion startVersion, ScmVersion endVersion,
                                                           String datePattern )
-            throws ScmException
+        throws ScmException
     {
         throw new ScmException( "Unsupported method for this provider." );
     }
@@ -60,8 +60,7 @@ public abstract class AbstractChangeLogCommand
                                                           String datePattern, boolean startFromRoot )
             throws ScmException
     {
-        // by default let's just delegate to executeChangeLogCommand with both start and end versions
-        return executeChangeLogCommand( repository, fileSet, null, endVersion, datePattern );
+        throw new ScmException( "Unsupported method for this provider." );
     }
 
     /**

--- a/maven-scm-api/src/main/java/org/apache/maven/scm/command/changelog/AbstractChangeLogCommand.java
+++ b/maven-scm-api/src/main/java/org/apache/maven/scm/command/changelog/AbstractChangeLogCommand.java
@@ -57,7 +57,7 @@ public abstract class AbstractChangeLogCommand
 
     protected ChangeLogScmResult executeChangeLogCommand( ScmProviderRepository repository, ScmFileSet fileSet,
                                                           ScmVersion endVersion,
-                                                          String datePattern, boolean startFromRoot )
+                                                          String datePattern, boolean fromStartOfRepository )
             throws ScmException
     {
         throw new ScmException( "Unsupported method for this provider." );
@@ -90,13 +90,13 @@ public abstract class AbstractChangeLogCommand
 
         String datePattern = parameters.getString( CommandParameter.CHANGELOG_DATE_PATTERN, null );
 
-        boolean startFromRoot = parameters.getBoolean( CommandParameter.START_FROM_ROOT, false );
+        boolean fromStartOfRepository = parameters.getBoolean( CommandParameter.FROM_START_OF_REPOSITORY, false );
 
         if ( startVersion != null || endVersion != null )
         {
-            if ( startVersion == null && startFromRoot )
+            if ( startVersion == null && fromStartOfRepository )
             {
-                return executeChangeLogCommand( repository, fileSet, endVersion, datePattern, startFromRoot );
+                return executeChangeLogCommand( repository, fileSet, endVersion, datePattern, fromStartOfRepository );
             }
             else
             {

--- a/maven-scm-api/src/main/java/org/apache/maven/scm/command/changelog/AbstractChangeLogCommand.java
+++ b/maven-scm-api/src/main/java/org/apache/maven/scm/command/changelog/AbstractChangeLogCommand.java
@@ -50,9 +50,18 @@ public abstract class AbstractChangeLogCommand
     protected ChangeLogScmResult executeChangeLogCommand( ScmProviderRepository repository, ScmFileSet fileSet,
                                                           ScmVersion startVersion, ScmVersion endVersion,
                                                           String datePattern )
-        throws ScmException
+            throws ScmException
     {
         throw new ScmException( "Unsupported method for this provider." );
+    }
+
+    protected ChangeLogScmResult executeChangeLogCommand( ScmProviderRepository repository, ScmFileSet fileSet,
+                                                          ScmVersion endVersion,
+                                                          String datePattern, boolean startFromRoot )
+            throws ScmException
+    {
+        // by default let's just delegate to executeChangeLogCommand with both start and end versions
+        return executeChangeLogCommand( repository, fileSet, null, endVersion, datePattern );
     }
 
     /**
@@ -82,9 +91,18 @@ public abstract class AbstractChangeLogCommand
 
         String datePattern = parameters.getString( CommandParameter.CHANGELOG_DATE_PATTERN, null );
 
+        boolean startFromRoot = parameters.getBoolean( CommandParameter.START_FROM_ROOT, false );
+
         if ( startVersion != null || endVersion != null )
         {
-            return executeChangeLogCommand( repository, fileSet, startVersion, endVersion, datePattern );
+            if ( startVersion == null && startFromRoot )
+            {
+                return executeChangeLogCommand( repository, fileSet, endVersion, datePattern, startFromRoot );
+            }
+            else
+            {
+                return executeChangeLogCommand( repository, fileSet, startVersion, endVersion, datePattern );
+            }
         }
         else
         {

--- a/maven-scm-api/src/main/java/org/apache/maven/scm/command/changelog/ChangeLogScmRequest.java
+++ b/maven-scm-api/src/main/java/org/apache/maven/scm/command/changelog/ChangeLogScmRequest.java
@@ -130,6 +130,18 @@ public class ChangeLogScmRequest
         parameters.setScmVersion( CommandParameter.END_SCM_VERSION, endRevision );
     }
 
+    public boolean getStartFromRoot()
+        throws ScmException
+    {
+        return parameters.getBoolean( CommandParameter.START_FROM_ROOT, false );
+    }
+
+    public void setStartFromRoot()
+            throws ScmException
+    {
+        parameters.setString( CommandParameter.START_FROM_ROOT, Boolean.TRUE.toString() );
+    }
+
     public String getDatePattern()
         throws ScmException
     {

--- a/maven-scm-api/src/main/java/org/apache/maven/scm/command/changelog/ChangeLogScmRequest.java
+++ b/maven-scm-api/src/main/java/org/apache/maven/scm/command/changelog/ChangeLogScmRequest.java
@@ -137,7 +137,7 @@ public class ChangeLogScmRequest
     }
 
     public void setStartFromRoot()
-            throws ScmException
+        throws ScmException
     {
         parameters.setString( CommandParameter.START_FROM_ROOT, Boolean.TRUE.toString() );
     }

--- a/maven-scm-api/src/main/java/org/apache/maven/scm/command/changelog/ChangeLogScmRequest.java
+++ b/maven-scm-api/src/main/java/org/apache/maven/scm/command/changelog/ChangeLogScmRequest.java
@@ -130,16 +130,16 @@ public class ChangeLogScmRequest
         parameters.setScmVersion( CommandParameter.END_SCM_VERSION, endRevision );
     }
 
-    public boolean getStartFromRoot()
+    public boolean isFromStartOfRepository()
         throws ScmException
     {
-        return parameters.getBoolean( CommandParameter.START_FROM_ROOT, false );
+        return parameters.getBoolean( CommandParameter.FROM_START_OF_REPOSITORY, false );
     }
 
-    public void setStartFromRoot()
+    public void setFromStartOfRepository()
         throws ScmException
     {
-        parameters.setString( CommandParameter.START_FROM_ROOT, Boolean.TRUE.toString() );
+        parameters.setString( CommandParameter.FROM_START_OF_REPOSITORY, Boolean.TRUE.toString() );
     }
 
     public String getDatePattern()

--- a/maven-scm-providers/maven-scm-providers-git/maven-scm-provider-gitexe/src/main/java/org/apache/maven/scm/provider/git/gitexe/command/changelog/GitChangeLogCommand.java
+++ b/maven-scm-providers/maven-scm-providers-git/maven-scm-provider-gitexe/src/main/java/org/apache/maven/scm/provider/git/gitexe/command/changelog/GitChangeLogCommand.java
@@ -63,11 +63,11 @@ public class GitChangeLogCommand
     /** {@inheritDoc} */
     protected ChangeLogScmResult executeChangeLogCommand( ScmProviderRepository repo, ScmFileSet fileSet,
                                                           ScmVersion endVersion, String datePattern,
-                                                          boolean startFromRoot )
+                                                          boolean fromStartOfRepository)
         throws ScmException
     {
         return executeChangeLogCommand( repo, fileSet, null, null, null, datePattern, null, endVersion, null,
-                                        startFromRoot );
+                fromStartOfRepository);
     }
 
     /** {@inheritDoc} */
@@ -99,7 +99,7 @@ public class GitChangeLogCommand
         final String datePattern = request.getDatePattern();
         return executeChangeLogCommand( request.getScmRepository().getProviderRepository(), fileSet,
             request.getStartDate(), request.getEndDate(), request.getScmBranch(), datePattern, startVersion,
-                endVersion, request.getLimit(), request.getStartFromRoot() );
+                endVersion, request.getLimit(), request.isFromStartOfRepository() );
     }
 
     protected ChangeLogScmResult executeChangeLogCommand( ScmProviderRepository repo, ScmFileSet fileSet,
@@ -116,11 +116,12 @@ public class GitChangeLogCommand
     protected ChangeLogScmResult executeChangeLogCommand( ScmProviderRepository repo, ScmFileSet fileSet,
                                                           Date startDate, Date endDate, ScmBranch branch,
                                                           String datePattern, ScmVersion startVersion,
-                                                          ScmVersion endVersion, Integer limit, boolean startFromRoot )
+                                                          ScmVersion endVersion, Integer limit,
+                                                          boolean fromStartOfRepository )
         throws ScmException
     {
         Commandline cl = createCommandLine( (GitScmProviderRepository) repo, fileSet.getBasedir(), branch, startDate,
-                                            endDate, startVersion, endVersion, limit, startFromRoot );
+                                            endDate, startVersion, endVersion, limit, fromStartOfRepository );
 
         GitChangeLogConsumer consumer = new GitChangeLogConsumer( getLogger(), datePattern );
 
@@ -168,7 +169,7 @@ public class GitChangeLogCommand
     static Commandline createCommandLine( GitScmProviderRepository repository, File workingDirectory,
                                                  ScmBranch branch, Date startDate, Date endDate,
                                                  ScmVersion startVersion, ScmVersion endVersion, Integer limit,
-                                                 boolean startFromRoot )
+                                                 boolean fromStartOfRepository )
     {
         SimpleDateFormat dateFormat = new SimpleDateFormat( DATE_FORMAT );
         dateFormat.setTimeZone( TimeZone.getTimeZone( "GMT" ) );
@@ -202,7 +203,7 @@ public class GitChangeLogCommand
                 versionRange.append( StringUtils.escape( startVersion.getName() ) );
             }
 
-            if ( startVersion != null || !startFromRoot )
+            if ( startVersion != null || !fromStartOfRepository )
             {
                 versionRange.append( ".." );
             }

--- a/maven-scm-providers/maven-scm-providers-git/maven-scm-provider-gitexe/src/main/java/org/apache/maven/scm/provider/git/gitexe/command/changelog/GitChangeLogCommand.java
+++ b/maven-scm-providers/maven-scm-providers-git/maven-scm-provider-gitexe/src/main/java/org/apache/maven/scm/provider/git/gitexe/command/changelog/GitChangeLogCommand.java
@@ -162,10 +162,10 @@ public class GitChangeLogCommand
                                           ScmBranch branch, Date startDate, Date endDate,
                                           ScmVersion startVersion, ScmVersion endVersion, Integer limit )
     {
-        return createCommandLine(
-                repository, workingDirectory, branch, startDate, endDate, startVersion, endVersion, limit, false
-        );
+        return createCommandLine( repository, workingDirectory, branch, startDate, endDate, startVersion, endVersion,
+                                    limit, false );
     }
+    
     static Commandline createCommandLine( GitScmProviderRepository repository, File workingDirectory,
                                                  ScmBranch branch, Date startDate, Date endDate,
                                                  ScmVersion startVersion, ScmVersion endVersion, Integer limit,

--- a/maven-scm-providers/maven-scm-providers-git/maven-scm-provider-gitexe/src/main/java/org/apache/maven/scm/provider/git/gitexe/command/changelog/GitChangeLogCommand.java
+++ b/maven-scm-providers/maven-scm-providers-git/maven-scm-provider-gitexe/src/main/java/org/apache/maven/scm/provider/git/gitexe/command/changelog/GitChangeLogCommand.java
@@ -63,11 +63,11 @@ public class GitChangeLogCommand
     /** {@inheritDoc} */
     protected ChangeLogScmResult executeChangeLogCommand( ScmProviderRepository repo, ScmFileSet fileSet,
                                                           ScmVersion endVersion, String datePattern,
-                                                          boolean fromStartOfRepository)
+                                                          boolean fromStartOfRepository )
         throws ScmException
     {
         return executeChangeLogCommand( repo, fileSet, null, null, null, datePattern, null, endVersion, null,
-                fromStartOfRepository);
+                fromStartOfRepository );
     }
 
     /** {@inheritDoc} */

--- a/maven-scm-providers/maven-scm-providers-git/maven-scm-provider-gitexe/src/main/java/org/apache/maven/scm/provider/git/gitexe/command/changelog/GitChangeLogCommand.java
+++ b/maven-scm-providers/maven-scm-providers-git/maven-scm-provider-gitexe/src/main/java/org/apache/maven/scm/provider/git/gitexe/command/changelog/GitChangeLogCommand.java
@@ -57,7 +57,20 @@ public class GitChangeLogCommand
                                                           String datePattern )
         throws ScmException
     {
-        return executeChangeLogCommand( repo, fileSet, null, null, null, datePattern, startVersion, endVersion );
+        return executeChangeLogCommand(
+                repo, fileSet, null, null, null, datePattern, startVersion, endVersion
+        );
+    }
+
+    /** {@inheritDoc} */
+    protected ChangeLogScmResult executeChangeLogCommand( ScmProviderRepository repo, ScmFileSet fileSet,
+                                                          ScmVersion endVersion, String datePattern,
+                                                          boolean startFromRoot )
+            throws ScmException
+    {
+        return executeChangeLogCommand(
+                repo, fileSet, null, null, null, datePattern, null, endVersion, null, startFromRoot
+        );
     }
 
     /** {@inheritDoc} */
@@ -89,17 +102,28 @@ public class GitChangeLogCommand
         final String datePattern = request.getDatePattern();
         return executeChangeLogCommand( request.getScmRepository().getProviderRepository(), fileSet,
             request.getStartDate(), request.getEndDate(), request.getScmBranch(), datePattern, startVersion,
-                endVersion, request.getLimit() );
+                endVersion, request.getLimit(), request.getStartFromRoot() );
     }
 
     protected ChangeLogScmResult executeChangeLogCommand( ScmProviderRepository repo, ScmFileSet fileSet,
                                                           Date startDate, Date endDate, ScmBranch branch,
                                                           String datePattern, ScmVersion startVersion,
                                                           ScmVersion endVersion, Integer limit )
+            throws ScmException
+    {
+        return executeChangeLogCommand(
+                repo, fileSet, startDate, endDate, branch, datePattern, startVersion, endVersion, limit, false
+        );
+    }
+
+    protected ChangeLogScmResult executeChangeLogCommand( ScmProviderRepository repo, ScmFileSet fileSet,
+                                                          Date startDate, Date endDate, ScmBranch branch,
+                                                          String datePattern, ScmVersion startVersion,
+                                                          ScmVersion endVersion, Integer limit, boolean startFromRoot )
         throws ScmException
     {
         Commandline cl = createCommandLine( (GitScmProviderRepository) repo, fileSet.getBasedir(), branch, startDate,
-                                            endDate, startVersion, endVersion, limit );
+                                            endDate, startVersion, endVersion, limit, startFromRoot );
 
         GitChangeLogConsumer consumer = new GitChangeLogConsumer( getLogger(), datePattern );
 
@@ -137,8 +161,17 @@ public class GitChangeLogCommand
     }
 
     static Commandline createCommandLine( GitScmProviderRepository repository, File workingDirectory,
+                                          ScmBranch branch, Date startDate, Date endDate,
+                                          ScmVersion startVersion, ScmVersion endVersion, Integer limit )
+    {
+        return createCommandLine(
+                repository, workingDirectory, branch, startDate, endDate, startVersion, endVersion, limit, false
+        );
+    }
+    static Commandline createCommandLine( GitScmProviderRepository repository, File workingDirectory,
                                                  ScmBranch branch, Date startDate, Date endDate,
-                                                 ScmVersion startVersion, ScmVersion endVersion, Integer limit )
+                                                 ScmVersion startVersion, ScmVersion endVersion, Integer limit,
+                                                 boolean startFromRoot )
     {
         SimpleDateFormat dateFormat = new SimpleDateFormat( DATE_FORMAT );
         dateFormat.setTimeZone( TimeZone.getTimeZone( "GMT" ) );
@@ -166,14 +199,17 @@ public class GitChangeLogCommand
         if ( startVersion != null || endVersion != null )
         {
             StringBuilder versionRange = new StringBuilder();
-            
+
             if ( startVersion != null )
             {
                 versionRange.append( StringUtils.escape( startVersion.getName() ) );
             }
 
-            versionRange.append( ".." );
-            
+            if ( startVersion != null || !startFromRoot )
+            {
+                versionRange.append( ".." );
+            }
+
             if ( endVersion != null )
             {
                 versionRange.append( StringUtils.escape( endVersion.getName() ) );

--- a/maven-scm-providers/maven-scm-providers-git/maven-scm-provider-gitexe/src/main/java/org/apache/maven/scm/provider/git/gitexe/command/changelog/GitChangeLogCommand.java
+++ b/maven-scm-providers/maven-scm-providers-git/maven-scm-provider-gitexe/src/main/java/org/apache/maven/scm/provider/git/gitexe/command/changelog/GitChangeLogCommand.java
@@ -57,20 +57,17 @@ public class GitChangeLogCommand
                                                           String datePattern )
         throws ScmException
     {
-        return executeChangeLogCommand(
-                repo, fileSet, null, null, null, datePattern, startVersion, endVersion
-        );
+        return executeChangeLogCommand( repo, fileSet, null, null, null, datePattern, startVersion, endVersion );
     }
 
     /** {@inheritDoc} */
     protected ChangeLogScmResult executeChangeLogCommand( ScmProviderRepository repo, ScmFileSet fileSet,
                                                           ScmVersion endVersion, String datePattern,
                                                           boolean startFromRoot )
-            throws ScmException
+        throws ScmException
     {
-        return executeChangeLogCommand(
-                repo, fileSet, null, null, null, datePattern, null, endVersion, null, startFromRoot
-        );
+        return executeChangeLogCommand( repo, fileSet, null, null, null, datePattern, null, endVersion, null,
+                                        startFromRoot );
     }
 
     /** {@inheritDoc} */
@@ -109,7 +106,7 @@ public class GitChangeLogCommand
                                                           Date startDate, Date endDate, ScmBranch branch,
                                                           String datePattern, ScmVersion startVersion,
                                                           ScmVersion endVersion, Integer limit )
-            throws ScmException
+        throws ScmException
     {
         return executeChangeLogCommand(
                 repo, fileSet, startDate, endDate, branch, datePattern, startVersion, endVersion, limit, false

--- a/maven-scm-providers/maven-scm-providers-git/maven-scm-provider-gitexe/src/test/java/org/apache/maven/scm/provider/git/gitexe/command/changelog/GitChangeLogCommandTest.java
+++ b/maven-scm-providers/maven-scm-providers-git/maven-scm-provider-gitexe/src/test/java/org/apache/maven/scm/provider/git/gitexe/command/changelog/GitChangeLogCommandTest.java
@@ -143,6 +143,14 @@ public class GitChangeLogCommandTest
                          + " -- " + StringUtils.quoteAndEscape( workingDirectory.getPath(), '"' ) );
     }
 
+    public void testCommandLineWithEndVersionStartingFromRoot()
+        throws Exception
+    {
+        testCommandLine( "scm:git:http://foo.com/git", null, new ScmRevision( "10" ),
+                         "git whatchanged --date=iso 10"
+                         + " -- " + StringUtils.quoteAndEscape( workingDirectory.getPath(), '"' ) );
+    }
+
     public void testCommandLineWithStartVersionAndEndVersionEquals()
         throws Exception
     {
@@ -178,6 +186,19 @@ public class GitChangeLogCommandTest
 
         Commandline cl = GitChangeLogCommand.createCommandLine( gitRepository, workingDirectory, branch, startDate,
                                                                 endDate, null, null, limit );
+
+        assertCommandLine( commandLine, workingDirectory, cl );
+    }
+
+    private void testCommandLine( String scmUrl, ScmBranch branch, ScmVersion endVersion, String commandLine )
+            throws Exception
+    {
+        ScmRepository repository = getScmManager().makeScmRepository( scmUrl );
+
+        GitScmProviderRepository gitRepository = (GitScmProviderRepository) repository.getProviderRepository();
+
+        Commandline cl = GitChangeLogCommand.createCommandLine( gitRepository, workingDirectory, branch, null, null,
+                null, endVersion, null, true );
 
         assertCommandLine( commandLine, workingDirectory, cl );
     }

--- a/maven-scm-providers/maven-scm-providers-git/maven-scm-provider-gittest/src/main/java/org/apache/maven/scm/provider/git/command/changelog/GitChangeLogCommandTckTest.java
+++ b/maven-scm-providers/maven-scm-providers-git/maven-scm-provider-gittest/src/main/java/org/apache/maven/scm/provider/git/command/changelog/GitChangeLogCommandTckTest.java
@@ -60,6 +60,93 @@ public abstract class GitChangeLogCommandTckTest
         }
     }
 
+    public void testChangeLogCommandBetweenHeadAndPreviousCommit()
+            throws Exception
+    {
+        Thread.sleep( 1000 );
+        ScmRepository scmRepository = getScmRepository();
+        ScmProvider provider = getScmManager().getProviderByRepository( scmRepository );
+        ScmFileSet fileSet = new ScmFileSet( getWorkingCopy() );
+
+        ChangeLogScmRequest clr = new ChangeLogScmRequest( scmRepository, fileSet );
+        // We set only endRevision to HEAD
+        clr.setStartRevision( new ScmRevision( "HEAD~1" ) );
+        clr.setEndRevision( new ScmRevision( "HEAD" ) );
+
+        //Make a change to the readme.txt and commit the change
+        this.edit( getWorkingCopy(), "readme.txt", null, getScmRepository() );
+        ScmTestCase.makeFile( getWorkingCopy(), "/readme.txt", "changed readme.txt" );
+        CheckInScmResult checkInResult = provider.checkIn( getScmRepository(), fileSet, "dummy commit message" );
+        assertTrue( "Unable to checkin changes to the repository", checkInResult.isSuccess() );
+
+        ChangeLogScmResult result = provider.changeLog( clr );
+        assertTrue( result.getProviderMessage(), result.isSuccess() );
+        assertEquals(
+                "the changelog from root does not have good commits number",
+                1, result.getChangeLog().getChangeSets().size()
+        );
+    }
+
+    public void testChangeIsEmptyForVersionHeadToHead()
+            throws Exception
+    {
+        Thread.sleep( 1000 );
+        ScmRepository scmRepository = getScmRepository();
+        ScmProvider provider = getScmManager().getProviderByRepository( scmRepository );
+        ScmFileSet fileSet = new ScmFileSet( getWorkingCopy() );
+
+        ChangeLogScmRequest clr = new ChangeLogScmRequest( scmRepository, fileSet );
+        // We set only endRevision to HEAD
+        clr.setStartRevision( new ScmRevision( "HEAD" ) );
+        clr.setEndRevision( new ScmRevision( "HEAD" ) );
+
+        //Make a change to the readme.txt and commit the change
+        this.edit( getWorkingCopy(), "readme.txt", null, getScmRepository() );
+        ScmTestCase.makeFile( getWorkingCopy(), "/readme.txt", "changed readme.txt" );
+        CheckInScmResult checkInResult = provider.checkIn( getScmRepository(), fileSet, "dummy commit message" );
+        assertTrue( "Unable to checkin changes to the repository", checkInResult.isSuccess() );
+
+        ChangeLogScmResult result = provider.changeLog( clr );
+        assertTrue( result.getProviderMessage(), result.isSuccess() );
+        assertEquals(
+                "the changelog from root does not have good commits number",
+                0, result.getChangeLog().getChangeSets().size()
+        );
+    }
+
+
+    public void testChangeLogCommandWithOnlyEndVersion()
+            throws Exception
+    {
+        Thread.sleep( 1000 );
+        ScmRepository scmRepository = getScmRepository();
+        ScmProvider provider = getScmManager().getProviderByRepository( scmRepository );
+        ScmFileSet fileSet = new ScmFileSet( getWorkingCopy() );
+
+        ChangeLogScmRequest clr = new ChangeLogScmRequest( scmRepository, fileSet );
+
+        // We set only endRevision to HEAD
+        clr.setEndRevision( new ScmRevision( "HEAD" ) );
+        ChangeLogScmResult firstResult = provider.changeLog( clr );
+
+        int firstLogSize = firstResult.getChangeLog().getChangeSets().size();
+        assertEquals( "Unexpected initial log size", 0, firstLogSize );
+
+        Thread.sleep( 2000 );
+        //Make a change to the readme.txt and commit the change
+        this.edit( getWorkingCopy(), "readme.txt", null, getScmRepository() );
+        ScmTestCase.makeFile( getWorkingCopy(), "/readme.txt", "changed readme.txt" );
+        CheckInScmResult checkInResult = provider.checkIn( getScmRepository(), fileSet, "dummy commit message" );
+        assertTrue( "Unable to checkin changes to the repository", checkInResult.isSuccess() );
+
+        ChangeLogScmResult secondResult = provider.changeLog( clr );
+        assertTrue( secondResult.getProviderMessage(), secondResult.isSuccess() );
+        assertEquals(
+                "the changelog from root does not have good commits number",
+                0, secondResult.getChangeLog().getChangeSets().size()
+        );
+    }
+
     public void testChangeLogCommandFromRootToEnd()
             throws Exception
     {

--- a/maven-scm-providers/maven-scm-providers-git/maven-scm-provider-gittest/src/main/java/org/apache/maven/scm/provider/git/command/changelog/GitChangeLogCommandTckTest.java
+++ b/maven-scm-providers/maven-scm-providers-git/maven-scm-provider-gittest/src/main/java/org/apache/maven/scm/provider/git/command/changelog/GitChangeLogCommandTckTest.java
@@ -20,6 +20,13 @@ package org.apache.maven.scm.provider.git.command.changelog;
  */
 
 import org.apache.maven.scm.command.checkout.CheckOutScmResult;
+import org.apache.maven.scm.ScmFileSet;
+import org.apache.maven.scm.ScmRevision;
+import org.apache.maven.scm.ScmTestCase;
+import org.apache.maven.scm.command.changelog.ChangeLogScmRequest;
+import org.apache.maven.scm.command.changelog.ChangeLogScmResult;
+import org.apache.maven.scm.command.checkin.CheckInScmResult;
+import org.apache.maven.scm.provider.ScmProvider;
 import org.apache.maven.scm.provider.git.GitScmTestUtils;
 import org.apache.maven.scm.repository.ScmRepository;
 import org.apache.maven.scm.tck.command.changelog.ChangeLogCommandTckTest;
@@ -51,5 +58,36 @@ public abstract class GitChangeLogCommandTckTest
         {
             GitScmTestUtils.setDefaultUser( workingDirectory );
         }
+    }
+
+    public void testChangeLogCommandFromRootToEnd()
+            throws Exception
+    {
+        Thread.sleep( 1000 );
+        ScmRepository scmRepository = getScmRepository();
+        ScmProvider provider = getScmManager().getProviderByRepository( scmRepository );
+        ScmFileSet fileSet = new ScmFileSet( getWorkingCopy() );
+
+        ChangeLogScmRequest clr = new ChangeLogScmRequest( scmRepository, fileSet );
+        clr.setStartFromRoot();
+        clr.setEndRevision( new ScmRevision( "HEAD" ) );
+        ChangeLogScmResult firstResult = provider.changeLog( clr );
+
+        int firstLogSize = firstResult.getChangeLog().getChangeSets().size();
+        assertEquals( "Unexpected initial log size", 1, firstLogSize );
+
+        Thread.sleep( 2000 );
+        //Make a change to the readme.txt and commit the change
+        this.edit( getWorkingCopy(), "readme.txt", null, getScmRepository() );
+        ScmTestCase.makeFile( getWorkingCopy(), "/readme.txt", "changed readme.txt" );
+        CheckInScmResult checkInResult = provider.checkIn( getScmRepository(), fileSet, "dummy commit message" );
+        assertTrue( "Unable to checkin changes to the repository", checkInResult.isSuccess() );
+
+        ChangeLogScmResult secondResult = provider.changeLog( clr );
+        assertTrue( secondResult.getProviderMessage(), secondResult.isSuccess() );
+        assertEquals(
+                "the changelog from root does not have good commits number",
+                2, secondResult.getChangeLog().getChangeSets().size()
+        );
     }
 }

--- a/maven-scm-providers/maven-scm-providers-git/maven-scm-provider-gittest/src/main/java/org/apache/maven/scm/provider/git/command/changelog/GitChangeLogCommandTckTest.java
+++ b/maven-scm-providers/maven-scm-providers-git/maven-scm-provider-gittest/src/main/java/org/apache/maven/scm/provider/git/command/changelog/GitChangeLogCommandTckTest.java
@@ -156,7 +156,7 @@ public abstract class GitChangeLogCommandTckTest
         ScmFileSet fileSet = new ScmFileSet( getWorkingCopy() );
 
         ChangeLogScmRequest clr = new ChangeLogScmRequest( scmRepository, fileSet );
-        clr.setStartFromRoot();
+        clr.setFromStartOfRepository();
         clr.setEndRevision( new ScmRevision( "HEAD" ) );
         ChangeLogScmResult firstResult = provider.changeLog( clr );
 

--- a/maven-scm-providers/maven-scm-providers-git/maven-scm-provider-jgit/src/main/java/org/apache/maven/scm/provider/git/jgit/command/changelog/JGitChangeLogCommand.java
+++ b/maven-scm-providers/maven-scm-providers-git/maven-scm-provider-jgit/src/main/java/org/apache/maven/scm/provider/git/jgit/command/changelog/JGitChangeLogCommand.java
@@ -79,12 +79,11 @@ public class JGitChangeLogCommand
 
     protected ChangeLogScmResult executeChangeLogCommand( ScmProviderRepository repository, ScmFileSet fileSet,
                                                           ScmVersion endVersion,
-                                                          String datePattern, boolean fromStartOfRepository)
+                                                          String datePattern, boolean fromStartOfRepository )
             throws ScmException
     {
-        return executeChangeLogCommand(
-                repository, fileSet, null, null, null, datePattern, null, endVersion, fromStartOfRepository
-        );
+        return executeChangeLogCommand( repository, fileSet, null, null, null, datePattern, null, endVersion,
+                                        fromStartOfRepository );
     }
 
     protected ChangeLogScmResult executeChangeLogCommand( ScmProviderRepository repo, ScmFileSet fileSet,

--- a/maven-scm-providers/maven-scm-providers-git/maven-scm-provider-jgit/src/main/java/org/apache/maven/scm/provider/git/jgit/command/changelog/JGitChangeLogCommand.java
+++ b/maven-scm-providers/maven-scm-providers-git/maven-scm-provider-jgit/src/main/java/org/apache/maven/scm/provider/git/jgit/command/changelog/JGitChangeLogCommand.java
@@ -79,6 +79,17 @@ public class JGitChangeLogCommand
                                                           Date startDate, Date endDate, ScmBranch branch,
                                                           String datePattern, ScmVersion startVersion,
                                                           ScmVersion endVersion )
+            throws ScmException
+    {
+        return executeChangeLogCommand(
+                repo, fileSet, startDate, endDate, branch, datePattern, startVersion, endVersion, false
+        );
+    }
+
+    protected ChangeLogScmResult executeChangeLogCommand( ScmProviderRepository repo, ScmFileSet fileSet,
+                                                          Date startDate, Date endDate, ScmBranch branch,
+                                                          String datePattern, ScmVersion startVersion,
+                                                          ScmVersion endVersion, boolean startFromRoot )
         throws ScmException
     {
         Git git = null;

--- a/maven-scm-providers/maven-scm-providers-git/maven-scm-provider-jgit/src/main/java/org/apache/maven/scm/provider/git/jgit/command/changelog/JGitChangeLogCommand.java
+++ b/maven-scm-providers/maven-scm-providers-git/maven-scm-provider-jgit/src/main/java/org/apache/maven/scm/provider/git/jgit/command/changelog/JGitChangeLogCommand.java
@@ -79,11 +79,11 @@ public class JGitChangeLogCommand
 
     protected ChangeLogScmResult executeChangeLogCommand( ScmProviderRepository repository, ScmFileSet fileSet,
                                                           ScmVersion endVersion,
-                                                          String datePattern, boolean startFromRoot )
+                                                          String datePattern, boolean fromStartOfRepository)
             throws ScmException
     {
         return executeChangeLogCommand(
-                repository, fileSet, null, null, null, datePattern, null, endVersion, startFromRoot
+                repository, fileSet, null, null, null, datePattern, null, endVersion, fromStartOfRepository
         );
     }
 
@@ -101,7 +101,7 @@ public class JGitChangeLogCommand
     protected ChangeLogScmResult executeChangeLogCommand( ScmProviderRepository repo, ScmFileSet fileSet,
                                                           Date startDate, Date endDate, ScmBranch branch,
                                                           String datePattern, ScmVersion startVersion,
-                                                          ScmVersion endVersion, boolean startFromRoot )
+                                                          ScmVersion endVersion, boolean fromStartOfRepository )
         throws ScmException
     {
         Git git = null;
@@ -112,7 +112,7 @@ public class JGitChangeLogCommand
             String startRev = startVersion != null ? startVersion.getName() : null;
             String endRev = endVersion != null ? endVersion.getName() : null;
 
-            if ( endRev != null && startRev == null && !startFromRoot )
+            if ( endRev != null && startRev == null && !fromStartOfRepository )
             {
                 startRev = Constants.HEAD;
             }

--- a/maven-scm-providers/maven-scm-providers-git/maven-scm-provider-jgit/src/main/java/org/apache/maven/scm/provider/git/jgit/command/changelog/JGitChangeLogCommand.java
+++ b/maven-scm-providers/maven-scm-providers-git/maven-scm-provider-jgit/src/main/java/org/apache/maven/scm/provider/git/jgit/command/changelog/JGitChangeLogCommand.java
@@ -33,6 +33,7 @@ import org.apache.maven.scm.provider.git.jgit.command.JGitUtils;
 import org.eclipse.jgit.api.Git;
 import org.eclipse.jgit.errors.IncorrectObjectTypeException;
 import org.eclipse.jgit.errors.MissingObjectException;
+import org.eclipse.jgit.lib.Constants;
 import org.eclipse.jgit.lib.Repository;
 import org.eclipse.jgit.revwalk.RevCommit;
 import org.eclipse.jgit.revwalk.RevSort;
@@ -40,6 +41,7 @@ import org.eclipse.jgit.revwalk.RevSort;
 import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.Date;
 import java.util.List;
 
@@ -75,6 +77,16 @@ public class JGitChangeLogCommand
         return executeChangeLogCommand( repo, fileSet, startDate, endDate, branch, datePattern, null, null );
     }
 
+    protected ChangeLogScmResult executeChangeLogCommand( ScmProviderRepository repository, ScmFileSet fileSet,
+                                                          ScmVersion endVersion,
+                                                          String datePattern, boolean startFromRoot )
+            throws ScmException
+    {
+        return executeChangeLogCommand(
+                repository, fileSet, null, null, null, datePattern, null, endVersion, startFromRoot
+        );
+    }
+
     protected ChangeLogScmResult executeChangeLogCommand( ScmProviderRepository repo, ScmFileSet fileSet,
                                                           Date startDate, Date endDate, ScmBranch branch,
                                                           String datePattern, ScmVersion startVersion,
@@ -100,8 +112,20 @@ public class JGitChangeLogCommand
             String startRev = startVersion != null ? startVersion.getName() : null;
             String endRev = endVersion != null ? endVersion.getName() : null;
 
-            List<ChangeEntry> gitChanges =
-                this.whatchanged( git.getRepository(), null, startRev, endRev, startDate, endDate, -1 );
+            if ( endRev != null && startRev == null && !startFromRoot )
+            {
+                startRev = Constants.HEAD;
+            }
+
+            List<ChangeEntry> gitChanges = null;
+            if ( startRev != null && startRev.equals( endRev ) )
+            {
+                gitChanges = Collections.emptyList();
+            }
+            else
+            {
+                gitChanges = this.whatchanged( git.getRepository(), null, startRev, endRev, startDate, endDate, -1 );
+            }
 
             List<ChangeSet> modifications = new ArrayList<ChangeSet>( gitChanges.size() );
 
@@ -138,6 +162,7 @@ public class JGitChangeLogCommand
                                           Date fromDate, Date toDate, int maxLines )
         throws MissingObjectException, IncorrectObjectTypeException, IOException
     {
+
         List<RevCommit> revs = JGitUtils.getRevCommits( repo, sortings, fromRev, toRev, fromDate, toDate, maxLines );
         List<ChangeEntry> changes = new ArrayList<ChangeEntry>( revs.size() );
 


### PR DESCRIPTION
this PR is a fix for SCM-885 which keeps the git exe implementation backard compatible but thus introduces a new command parameter: START_FROM_ROOT

the PR also adds several TCK tests and provides corrections of existing faulty behaviors of the jgit implementation