### PR TITLE
[SCM-886] introduce helper class to configure git commit user

### DIFF
--- a/maven-scm-providers/maven-scm-providers-git/maven-scm-provider-gitexe/src/test/java/org/apache/maven/scm/provider/git/gitexe/command/checkin/GitCheckInCommandNoBranchTest.java
+++ b/maven-scm-providers/maven-scm-providers-git/maven-scm-provider-gitexe/src/test/java/org/apache/maven/scm/provider/git/gitexe/command/checkin/GitCheckInCommandNoBranchTest.java
@@ -25,6 +25,7 @@ import org.apache.maven.scm.ScmVersion;
 import org.apache.maven.scm.command.add.AddScmResult;
 import org.apache.maven.scm.command.checkin.CheckInScmResult;
 import org.apache.maven.scm.command.checkout.CheckOutScmResult;
+import org.apache.maven.scm.provider.git.GitScmTestUtils;
 import org.apache.maven.scm.repository.ScmRepository;
 import org.codehaus.plexus.util.FileUtils;
 
@@ -61,7 +62,12 @@ public class GitCheckInCommandNoBranchTest
         FileUtils.copyDirectoryStructure( repo_orig, repo );
 
         ScmRepository scmRepository = getScmManager().makeScmRepository( "scm:git:file:///" + repo.getAbsolutePath() );
+
         CheckOutScmResult checkOutScmResult = checkoutRepo( scmRepository );
+
+        // Add a default user to the config
+        GitScmTestUtils.setDefaultUser(workingDirectory);
+
         assertEquals( 0, checkOutScmResult.getCheckedOutFiles().size() );
 
         File f = new File( workingDirectory.getAbsolutePath() + File.separator + "pom.xml" );

--- a/maven-scm-providers/maven-scm-providers-git/maven-scm-provider-gitexe/src/test/java/org/apache/maven/scm/provider/git/gitexe/command/checkin/GitCheckInCommandTest.java
+++ b/maven-scm-providers/maven-scm-providers-git/maven-scm-provider-gitexe/src/test/java/org/apache/maven/scm/provider/git/gitexe/command/checkin/GitCheckInCommandTest.java
@@ -98,6 +98,9 @@ public class GitCheckInCommandTest
         ScmRepository scmRepository = getScmManager().makeScmRepository( "scm:git:file://" + repo.getAbsolutePath() );
         checkoutRepoInto(checkedOutRepo, scmRepository);
 
+        // Add a default user to the config
+        GitScmTestUtils.setDefaultUser(checkedOutRepo);
+
         // Creating foo/bar/wine.xml
         File fooDir = new File( checkedOutRepo.getAbsolutePath() + File.separator + "foo" );
         fooDir.mkdir();

--- a/maven-scm-providers/maven-scm-providers-git/maven-scm-provider-gittest/src/main/java/org/apache/maven/scm/provider/git/GitScmTestUtils.java
+++ b/maven-scm-providers/maven-scm-providers-git/maven-scm-provider-gittest/src/main/java/org/apache/maven/scm/provider/git/GitScmTestUtils.java
@@ -29,6 +29,7 @@ import org.codehaus.plexus.util.cli.CommandLineUtils;
 import org.codehaus.plexus.util.cli.Commandline;
 
 import java.io.File;
+import java.io.FileWriter;
 import java.io.IOException;
 
 /**
@@ -136,4 +137,38 @@ public final class GitScmTestUtils
         }
     }
 
+    public static void setDefaultUser( File repositoryRootFile )
+    {
+        File gitConfigFile = new File( new File( repositoryRootFile, ".git" ), "config" );
+
+        FileWriter fw = null;
+        try
+        {
+            fw = new FileWriter( gitConfigFile , true );
+            fw.append( "[user]\n" );
+            fw.append( "\tname = John Doe\n" );
+            fw.append( "\temail = john.doe@nowhere.com\n" );
+            fw.flush();
+            fw.close();
+        }
+        catch ( IOException e )
+        {
+            System.err.println( "cannot setup a default user for tests purpose inside " + gitConfigFile );
+            e.printStackTrace();
+        }
+        finally
+        {
+            if ( fw != null )
+            {
+                try
+                {
+                    fw.close();
+                }
+                catch ( IOException ignore )
+                {
+                    // ignored
+                }
+            }
+        }
+    }
 }

--- a/maven-scm-providers/maven-scm-providers-git/maven-scm-provider-gittest/src/main/java/org/apache/maven/scm/provider/git/command/blame/GitBlameCommandTckTest.java
+++ b/maven-scm-providers/maven-scm-providers-git/maven-scm-provider-gittest/src/main/java/org/apache/maven/scm/provider/git/command/blame/GitBlameCommandTckTest.java
@@ -19,8 +19,12 @@ package org.apache.maven.scm.provider.git.command.blame;
  * under the License.
  */
 
+import org.apache.maven.scm.command.checkout.CheckOutScmResult;
 import org.apache.maven.scm.provider.git.GitScmTestUtils;
+import org.apache.maven.scm.repository.ScmRepository;
 import org.apache.maven.scm.tck.command.blame.BlameCommandTckTest;
+
+import java.io.File;
 
 /**
  * @author Evgeny Mandrikov
@@ -33,5 +37,18 @@ public abstract class GitBlameCommandTckTest
         throws Exception
     {
         GitScmTestUtils.initRepo( "src/test/resources/repository/", getRepositoryRoot(), getWorkingDirectory() );
+    }
+
+    @Override
+    protected CheckOutScmResult checkOut( File workingDirectory, ScmRepository repository ) throws Exception
+    {
+        try
+        {
+            return super.checkOut( workingDirectory, repository );
+        }
+        finally
+        {
+            GitScmTestUtils.setDefaultUser( workingDirectory );
+        }
     }
 }

--- a/maven-scm-providers/maven-scm-providers-git/maven-scm-provider-gittest/src/main/java/org/apache/maven/scm/provider/git/command/branch/GitBranchCommandTckTest.java
+++ b/maven-scm-providers/maven-scm-providers-git/maven-scm-provider-gittest/src/main/java/org/apache/maven/scm/provider/git/command/branch/GitBranchCommandTckTest.java
@@ -19,8 +19,12 @@ package org.apache.maven.scm.provider.git.command.branch;
  * under the License.
  */
 
+import org.apache.maven.scm.command.checkout.CheckOutScmResult;
 import org.apache.maven.scm.provider.git.GitScmTestUtils;
+import org.apache.maven.scm.repository.ScmRepository;
 import org.apache.maven.scm.tck.command.branch.BranchCommandTckTest;
+
+import java.io.File;
 
 /**
  * @author <a href="mailto:struberg@yahoo.de">Mark Struberg</a>
@@ -34,5 +38,18 @@ public abstract class GitBranchCommandTckTest
         throws Exception
     {
         GitScmTestUtils.initRepo( "src/test/resources/repository/", getRepositoryRoot(), getWorkingDirectory() );
+    }
+
+    @Override
+    protected CheckOutScmResult checkOut( File workingDirectory, ScmRepository repository ) throws Exception
+    {
+        try
+        {
+            return super.checkOut( workingDirectory, repository );
+        }
+        finally
+        {
+            GitScmTestUtils.setDefaultUser( workingDirectory );
+        }
     }
 }

--- a/maven-scm-providers/maven-scm-providers-git/maven-scm-provider-gittest/src/main/java/org/apache/maven/scm/provider/git/command/changelog/GitChangeLogCommandTckTest.java
+++ b/maven-scm-providers/maven-scm-providers-git/maven-scm-provider-gittest/src/main/java/org/apache/maven/scm/provider/git/command/changelog/GitChangeLogCommandTckTest.java
@@ -19,8 +19,12 @@ package org.apache.maven.scm.provider.git.command.changelog;
  * under the License.
  */
 
+import org.apache.maven.scm.command.checkout.CheckOutScmResult;
 import org.apache.maven.scm.provider.git.GitScmTestUtils;
+import org.apache.maven.scm.repository.ScmRepository;
 import org.apache.maven.scm.tck.command.changelog.ChangeLogCommandTckTest;
+
+import java.io.File;
 
 /**
  * @author <a href="mailto:struberg@yahoo.de">Mark Struberg</a>
@@ -36,4 +40,16 @@ public abstract class GitChangeLogCommandTckTest
         GitScmTestUtils.initRepo( "src/test/resources/repository/", getRepositoryRoot(), getWorkingDirectory() );
     }
 
+    @Override
+    protected CheckOutScmResult checkOut( File workingDirectory, ScmRepository repository ) throws Exception
+    {
+        try
+        {
+            return super.checkOut( workingDirectory, repository );
+        }
+        finally
+        {
+            GitScmTestUtils.setDefaultUser( workingDirectory );
+        }
+    }
 }

--- a/maven-scm-providers/maven-scm-providers-git/maven-scm-provider-gittest/src/main/java/org/apache/maven/scm/provider/git/command/checkin/GitCheckInCommandTckTest.java
+++ b/maven-scm-providers/maven-scm-providers-git/maven-scm-provider-gittest/src/main/java/org/apache/maven/scm/provider/git/command/checkin/GitCheckInCommandTckTest.java
@@ -19,8 +19,12 @@ package org.apache.maven.scm.provider.git.command.checkin;
  * under the License.
  */
 
+import org.apache.maven.scm.command.checkout.CheckOutScmResult;
 import org.apache.maven.scm.provider.git.GitScmTestUtils;
+import org.apache.maven.scm.repository.ScmRepository;
 import org.apache.maven.scm.tck.command.checkin.CheckInCommandTckTest;
+
+import java.io.File;
 
 /**
  * @author <a href="mailto:struberg@yahoo.de">Mark Struberg</a>
@@ -35,5 +39,18 @@ public abstract class GitCheckInCommandTckTest
         throws Exception
     {
         GitScmTestUtils.initRepo( "src/test/resources/repository/", getRepositoryRoot(), getWorkingDirectory() );
+    }
+
+    @Override
+    protected CheckOutScmResult checkOut( File workingDirectory, ScmRepository repository ) throws Exception
+    {
+        try
+        {
+            return super.checkOut( workingDirectory, repository );
+        }
+        finally
+        {
+            GitScmTestUtils.setDefaultUser( workingDirectory );
+        }
     }
 }

--- a/maven-scm-providers/maven-scm-providers-git/maven-scm-provider-gittest/src/main/java/org/apache/maven/scm/provider/git/command/status/GitStatusCommandTckTest.java
+++ b/maven-scm-providers/maven-scm-providers-git/maven-scm-provider-gittest/src/main/java/org/apache/maven/scm/provider/git/command/status/GitStatusCommandTckTest.java
@@ -19,8 +19,12 @@ package org.apache.maven.scm.provider.git.command.status;
  * under the License.
  */
 
+import org.apache.maven.scm.command.checkout.CheckOutScmResult;
 import org.apache.maven.scm.provider.git.GitScmTestUtils;
+import org.apache.maven.scm.repository.ScmRepository;
 import org.apache.maven.scm.tck.command.status.StatusCommandTckTest;
+
+import java.io.File;
 
 /**
  * @author <a href="mailto:struberg@yahoo.de">Mark Struberg</a>
@@ -34,5 +38,18 @@ public abstract class GitStatusCommandTckTest
         throws Exception
     {
         GitScmTestUtils.initRepo( "src/test/resources/repository/", getRepositoryRoot(), getWorkingDirectory() );
+    }
+
+    @Override
+    protected CheckOutScmResult checkOut( File workingDirectory, ScmRepository repository ) throws Exception
+    {
+        try
+        {
+            return super.checkOut( workingDirectory, repository );
+        }
+        finally
+        {
+            GitScmTestUtils.setDefaultUser( workingDirectory );
+        }
     }
 }

--- a/maven-scm-providers/maven-scm-providers-git/maven-scm-provider-gittest/src/main/java/org/apache/maven/scm/provider/git/command/tag/GitTagCommandTckTest.java
+++ b/maven-scm-providers/maven-scm-providers-git/maven-scm-provider-gittest/src/main/java/org/apache/maven/scm/provider/git/command/tag/GitTagCommandTckTest.java
@@ -19,8 +19,12 @@ package org.apache.maven.scm.provider.git.command.tag;
  * under the License.
  */
 
+import org.apache.maven.scm.command.checkout.CheckOutScmResult;
 import org.apache.maven.scm.provider.git.GitScmTestUtils;
+import org.apache.maven.scm.repository.ScmRepository;
 import org.apache.maven.scm.tck.command.tag.TagCommandTckTest;
+
+import java.io.File;
 
 /**
  * @author <a href="mailto:struberg@yahoo.de">Mark Struberg</a>
@@ -34,5 +38,18 @@ public abstract class GitTagCommandTckTest
         throws Exception
     {
         GitScmTestUtils.initRepo( "src/test/resources/repository/", getRepositoryRoot(), getWorkingDirectory() );
+    }
+
+    @Override
+    protected CheckOutScmResult checkOut( File workingDirectory, ScmRepository repository ) throws Exception
+    {
+        try
+        {
+            return super.checkOut( workingDirectory, repository );
+        }
+        finally
+        {
+            GitScmTestUtils.setDefaultUser( workingDirectory );
+        }
     }
 }

--- a/maven-scm-providers/maven-scm-providers-git/maven-scm-provider-gittest/src/main/java/org/apache/maven/scm/provider/git/command/update/GitUpdateCommandTckTest.java
+++ b/maven-scm-providers/maven-scm-providers-git/maven-scm-provider-gittest/src/main/java/org/apache/maven/scm/provider/git/command/update/GitUpdateCommandTckTest.java
@@ -19,8 +19,12 @@ package org.apache.maven.scm.provider.git.command.update;
  * under the License.
  */
 
+import org.apache.maven.scm.command.checkout.CheckOutScmResult;
 import org.apache.maven.scm.provider.git.GitScmTestUtils;
+import org.apache.maven.scm.repository.ScmRepository;
 import org.apache.maven.scm.tck.command.update.UpdateCommandTckTest;
+
+import java.io.File;
 
 /**
  * @author <a href="mailto:struberg@yahoo.de">Mark Struberg</a>
@@ -34,5 +38,18 @@ public abstract class GitUpdateCommandTckTest
         throws Exception
     {
         GitScmTestUtils.initRepo( "src/test/resources/repository/", getRepositoryRoot(), getWorkingDirectory() );
+    }
+
+    @Override
+    protected CheckOutScmResult checkOut( File workingDirectory, ScmRepository repository ) throws Exception
+    {
+        try
+        {
+            return super.checkOut( workingDirectory, repository );
+        }
+        finally
+        {
+            GitScmTestUtils.setDefaultUser( workingDirectory );
+        }
     }
 }


### PR DESCRIPTION
in every tests performing some modifications in git repository (commits, ...)
a defaut user (name & email) is configured so that git commands succeed if no global user exists

fixes #SCM-886

Signed-off-by: Matthieu Brouillard <matthieu@brouillard.fr>