### PR TITLE
SCM-791,SCM-815: fixes for Windows paths in git command line

### DIFF
--- a/maven-scm-providers/maven-scm-providers-git/maven-scm-provider-git-commons/src/main/java/org/apache/maven/scm/provider/git/repository/GitScmProviderRepository.java
+++ b/maven-scm-providers/maven-scm-providers-git/maven-scm-provider-git-commons/src/main/java/org/apache/maven/scm/provider/git/repository/GitScmProviderRepository.java
@@ -19,14 +19,15 @@ package org.apache.maven.scm.provider.git.repository;
  * under the License.
  */
 
-import org.apache.maven.scm.ScmException;
-import org.apache.maven.scm.provider.ScmProviderRepository;
-import org.apache.maven.scm.provider.ScmProviderRepositoryWithHost;
-
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+
+import org.apache.maven.scm.ScmException;
+import org.apache.maven.scm.provider.ScmProviderRepository;
+import org.apache.maven.scm.provider.ScmProviderRepositoryWithHost;
+import org.codehaus.plexus.util.Os;
 
 /**
  * @author <a href="mailto:evenisse@apache.org">Emmanuel Venisse</a>
@@ -234,6 +235,9 @@ public class GitScmProviderRepository
         url = parseUserInfo( repoUrl, url );
         url = parseHostAndPort( repoUrl, url );
         // the rest of the url must be the path to the repository on the server
+        if ( PROTOCOL_FILE.equals( repoUrl.getProtocol() ) && Os.isFamily( Os.FAMILY_WINDOWS ) ) {
+            url = url.replace( '\\', '/' );
+        }
         repoUrl.setPath( url );
         return repoUrl;
     }

--- a/maven-scm-providers/maven-scm-providers-git/maven-scm-provider-git-commons/src/main/java/org/apache/maven/scm/provider/git/repository/GitScmProviderRepository.java
+++ b/maven-scm-providers/maven-scm-providers-git/maven-scm-provider-git-commons/src/main/java/org/apache/maven/scm/provider/git/repository/GitScmProviderRepository.java
@@ -19,15 +19,14 @@ package org.apache.maven.scm.provider.git.repository;
  * under the License.
  */
 
+import org.apache.maven.scm.ScmException;
+import org.apache.maven.scm.provider.ScmProviderRepository;
+import org.apache.maven.scm.provider.ScmProviderRepositoryWithHost;
+
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
-
-import org.apache.maven.scm.ScmException;
-import org.apache.maven.scm.provider.ScmProviderRepository;
-import org.apache.maven.scm.provider.ScmProviderRepositoryWithHost;
-import org.codehaus.plexus.util.Os;
 
 /**
  * @author <a href="mailto:evenisse@apache.org">Emmanuel Venisse</a>
@@ -235,9 +234,6 @@ public class GitScmProviderRepository
         url = parseUserInfo( repoUrl, url );
         url = parseHostAndPort( repoUrl, url );
         // the rest of the url must be the path to the repository on the server
-        if ( PROTOCOL_FILE.equals( repoUrl.getProtocol() ) && Os.isFamily( Os.FAMILY_WINDOWS ) ) {
-            url = url.replace( '\\', '/' );
-        }
         repoUrl.setPath( url );
         return repoUrl;
     }

--- a/maven-scm-providers/maven-scm-providers-git/maven-scm-provider-git-commons/src/test/java/org/apache/maven/scm/provider/git/repository/GitScmProviderRepositoryTest.java
+++ b/maven-scm-providers/maven-scm-providers-git/maven-scm-provider-git-commons/src/test/java/org/apache/maven/scm/provider/git/repository/GitScmProviderRepositoryTest.java
@@ -109,6 +109,7 @@ public class GitScmProviderRepositoryTest
     public void testLegalFileWindowsURL()
             throws Exception
     {
+        // FIXME This URL is invalid, hell knows why Git accepts it. It should be by us right away
         testUrl( "scm:git:file://c:\\tmp\\repo", null, "file://c:\\tmp\\repo", null, null, null, null, 0, null);
     }
 

--- a/maven-scm-providers/maven-scm-providers-git/maven-scm-provider-gitexe/src/main/java/org/apache/maven/scm/provider/git/gitexe/GitExeScmProvider.java
+++ b/maven-scm-providers/maven-scm-providers-git/maven-scm-provider-gitexe/src/main/java/org/apache/maven/scm/provider/git/gitexe/GitExeScmProvider.java
@@ -141,7 +141,8 @@ public class GitExeScmProvider
         // Note: I need to supply just 1 absolute path, but ScmFileSet won't let me without
         // a basedir (which isn't used here anyway), so use a dummy file.
         // and a dummy ScmProviderRepository
-        InfoScmResult result = info( new GitScmProviderRepository( path.getPath() ), new ScmFileSet( path ), null );
+        InfoScmResult result = info( new GitScmProviderRepository( path.toPath().toUri().toASCIIString() ),
+                                     new ScmFileSet( path ), null );
 
         if ( result.getInfoItems().size() != 1 )
         {

--- a/maven-scm-providers/maven-scm-providers-git/maven-scm-provider-gitexe/src/main/java/org/apache/maven/scm/provider/git/gitexe/command/GitCommandLineUtils.java
+++ b/maven-scm-providers/maven-scm-providers-git/maven-scm-provider-gitexe/src/main/java/org/apache/maven/scm/provider/git/gitexe/command/GitCommandLineUtils.java
@@ -19,6 +19,8 @@ package org.apache.maven.scm.provider.git.gitexe.command;
  * under the License.
  */
 
+import org.apache.commons.io.FilenameUtils;
+
 import org.apache.maven.scm.ScmException;
 import org.apache.maven.scm.log.ScmLogger;
 import org.apache.maven.scm.provider.git.util.GitUtil;
@@ -34,7 +36,7 @@ import java.util.List;
 
 /**
  * Command line construction utility.
- * 
+ *
  * @author Brett Porter
  * @author <a href="mailto:struberg@yahoo.de">Mark Struberg</a>
  *
@@ -73,7 +75,7 @@ public final class GitCommandLineUtils
                 }
 
                 // no setFile() since this screws up the working directory!
-                cl.createArg().setValue( relativeFile );
+                cl.createArg().setValue( FilenameUtils.separatorsToUnix( relativeFile ) );
             }
         }
         catch ( IOException ex )
@@ -84,7 +86,7 @@ public final class GitCommandLineUtils
     }
 
     /**
-     * 
+     *
      * @param workingDirectory
      * @param command
      * @return
@@ -97,7 +99,7 @@ public final class GitCommandLineUtils
     /**
      * Creates a {@link Commandline} for which the toString() do not display
      * password.
-     * 
+     *
      * @param workingDirectory
      * @param command
      * @return CommandLine with anonymous output.

--- a/maven-scm-providers/maven-scm-providers-git/maven-scm-provider-gitexe/src/main/java/org/apache/maven/scm/provider/git/gitexe/command/changelog/GitChangeLogCommand.java
+++ b/maven-scm-providers/maven-scm-providers-git/maven-scm-provider-gitexe/src/main/java/org/apache/maven/scm/provider/git/gitexe/command/changelog/GitChangeLogCommand.java
@@ -236,7 +236,7 @@ public class GitChangeLogCommand
         // We have to report only the changes of the current project.
         // This is needed for child projects, otherwise we would get the changelog of the 
         // whole parent-project including all childs.
-        cl.createArg().setFile( workingDirectory );
+        cl.createArg().setValue( "." );
         
         return cl;
     }

--- a/maven-scm-providers/maven-scm-providers-git/maven-scm-provider-gitexe/src/main/java/org/apache/maven/scm/provider/git/gitexe/command/checkout/GitCheckOutCommand.java
+++ b/maven-scm-providers/maven-scm-providers-git/maven-scm-provider-gitexe/src/main/java/org/apache/maven/scm/provider/git/gitexe/command/checkout/GitCheckOutCommand.java
@@ -194,7 +194,7 @@ public class GitCheckOutCommand
 
         cl.createArg().setValue( repository.getFetchUrl() );
 
-        cl.createArg().setFile( workingDirectory );
+        cl.createArg().setValue( workingDirectory.getName() );
 
         return cl;
     }
@@ -223,8 +223,8 @@ public class GitCheckOutCommand
                 // A tag will not be pulled but we only fetch all the commits from the upstream repo
                 // This is done because checking out a tag might not happen on the current branch
                 // but create a 'detached HEAD'.
-                // In fact, a tag in git may be in multiple branches. This occurs if 
-                // you create a branch after the tag has been created 
+                // In fact, a tag in git may be in multiple branches. This occurs if
+                // you create a branch after the tag has been created
                 cl = GitCommandLineUtils.getBaseGitCommandLine( workingDirectory, "fetch" );
 
                 cl.createArg().setValue( repository.getFetchUrl() );

--- a/maven-scm-providers/maven-scm-providers-git/maven-scm-provider-gitexe/src/main/java/org/apache/maven/scm/provider/git/gitexe/command/info/GitInfoConsumer.java
+++ b/maven-scm-providers/maven-scm-providers-git/maven-scm-provider-gitexe/src/main/java/org/apache/maven/scm/provider/git/gitexe/command/info/GitInfoConsumer.java
@@ -47,7 +47,7 @@ public class GitInfoConsumer
         super( logger );
         this.scmFileSet = scmFileSet;
     }
-    
+
     /**
      * @see org.codehaus.plexus.util.cli.StreamConsumer#consumeLine(java.lang.String)
      */
@@ -57,14 +57,14 @@ public class GitInfoConsumer
         {
             getLogger().debug( "consume line " + line );
         }
-        
+
         if ( infoItems.isEmpty() )
         {
             if ( !StringUtils.isEmpty( line ) )
             {
                 InfoItem infoItem = new InfoItem();
                 infoItem.setRevision( StringUtils.trim( line ) );
-                infoItem.setURL( scmFileSet.getBasedir().getPath() );
+                infoItem.setURL( scmFileSet.getBasedir().toPath().toUri().toASCIIString() );
                 infoItems.add( infoItem );
             }
         }

--- a/maven-scm-providers/maven-scm-providers-git/maven-scm-provider-gitexe/src/test/java/org/apache/maven/scm/provider/git/gitexe/command/GitCommandLineUtilsAddTargetTest.java
+++ b/maven-scm-providers/maven-scm-providers-git/maven-scm-provider-gitexe/src/test/java/org/apache/maven/scm/provider/git/gitexe/command/GitCommandLineUtilsAddTargetTest.java
@@ -65,7 +65,7 @@ public class GitCommandLineUtilsAddTargetTest
         // https://jira.codehaus.org/browse/SCM-667
         final List<File> filesToAdd = Arrays.asList( new File( "C:\\prj\\pom.xml" ),
             new File( "c:\\prj\\mod1\\pom.xml" ) );
-        final String expectedArguments = "[add, pom.xml, mod1\\pom.xml]";
+        final String expectedArguments = "[add, pom.xml, mod1/pom.xml]";
         check( workingDir, filesToAdd, expectedArguments );
     }
 

--- a/maven-scm-providers/maven-scm-providers-git/maven-scm-provider-gitexe/src/test/java/org/apache/maven/scm/provider/git/gitexe/command/changelog/GitChangeLogCommandTest.java
+++ b/maven-scm-providers/maven-scm-providers-git/maven-scm-provider-gitexe/src/test/java/org/apache/maven/scm/provider/git/gitexe/command/changelog/GitChangeLogCommandTest.java
@@ -53,7 +53,7 @@ public class GitChangeLogCommandTest
     {
         testCommandLine( "scm:git:http://foo.com/git", null, (Date) null, (Date) null, 40,
                          "git whatchanged --date=iso --max-count=40"
-                         + " -- " + StringUtils.quoteAndEscape( workingDirectory.getPath(), '"' ) );
+                         + " -- ." );
     }
 
     public void testCommandLineNoDatesLimitedCount()
@@ -61,7 +61,7 @@ public class GitChangeLogCommandTest
     {
         testCommandLine( "scm:git:http://foo.com/git", null, (Date) null, (Date) null,
                          "git whatchanged --date=iso"
-                         + " -- " + StringUtils.quoteAndEscape( workingDirectory.getPath(), '"' ) );
+                         + " -- ." );
     }
 
     public void testCommandLineWithDates()
@@ -72,7 +72,7 @@ public class GitChangeLogCommandTest
 
         testCommandLine( "scm:git:http://foo.com/git", null, startDate, endDate,
                          "git whatchanged \"--since=2003-09-10 00:00:00 +0000\" \"--until=2007-10-10 00:00:00 +0000\" --date=iso" 
-                         + " -- " + StringUtils.quoteAndEscape( workingDirectory.getPath(), '"' ) );
+                         + " -- ." );
     }
 
     public void testCommandLineStartDateOnly()
@@ -82,7 +82,7 @@ public class GitChangeLogCommandTest
 
         testCommandLine( "scm:git:http://foo.com/git", null, startDate, null,
                          "git whatchanged \"--since=2003-09-10 01:01:01 +0000\" --date=iso" 
-                         + " -- " + StringUtils.quoteAndEscape( workingDirectory.getPath(), '"' ) );
+                         + " -- ." );
     }
 
     public void testCommandLineDateFormat()
@@ -93,7 +93,7 @@ public class GitChangeLogCommandTest
 
         testCommandLine( "scm:git:http://foo.com/git", null, startDate, endDate,
                          "git whatchanged \"--since=2003-09-10 01:01:01 +0000\" \"--until=2005-11-13 23:23:23 +0000\" --date=iso"
-                         + " -- " + StringUtils.quoteAndEscape( workingDirectory.getPath(), '"' ) );
+                         + " -- ." );
     }
 
     public void testCommandLineDateVersionRanges()
@@ -104,7 +104,7 @@ public class GitChangeLogCommandTest
     
         testCommandLine( "scm:git:http://foo.com/git", null, startDate, endDate, new ScmRevision( "1" ), new ScmRevision( "10" ),
                          "git whatchanged \"--since=2003-09-10 01:01:01 +0000\" \"--until=2005-11-13 23:23:23 +0000\" --date=iso 1..10"
-                         + " -- " + StringUtils.quoteAndEscape( workingDirectory.getPath(), '"' ) );
+                         + " -- ." );
     }
     
     public void testCommandLineEndDateOnly()
@@ -115,7 +115,7 @@ public class GitChangeLogCommandTest
         // Only specifying end date should print no dates at all
         testCommandLine( "scm:git:http://foo.com/git", null, null, endDate,
                          "git whatchanged \"--until=2003-11-10 00:00:00 +0000\" --date=iso"
-                         + " -- " + StringUtils.quoteAndEscape( workingDirectory.getPath(), '"' ) );
+                         + " -- ." );
     }
 
     public void testCommandLineWithBranchNoDates()
@@ -123,7 +123,7 @@ public class GitChangeLogCommandTest
     {
         testCommandLine( "scm:git:http://foo.com/git", new ScmBranch( "my-test-branch" ), (Date) null, (Date) null, 
                          "git whatchanged --date=iso my-test-branch"
-                         + " -- " + StringUtils.quoteAndEscape( workingDirectory.getPath(), '"' ) );
+                         + " -- ." );
     }
 
 
@@ -132,7 +132,7 @@ public class GitChangeLogCommandTest
     {
         testCommandLine( "scm:git:http://foo.com/git", null, new ScmRevision( "1" ), null, 
                          "git whatchanged --date=iso 1.."
-                         + " -- " + StringUtils.quoteAndEscape( workingDirectory.getPath(), '"' ) );
+                         + " -- ." );
     }
 
     public void testCommandLineWithStartVersionAndEndVersion()
@@ -140,7 +140,7 @@ public class GitChangeLogCommandTest
     {
         testCommandLine( "scm:git:http://foo.com/git", null, new ScmRevision( "1" ), new ScmRevision( "10" ), 
                          "git whatchanged --date=iso 1..10"
-                         + " -- " + StringUtils.quoteAndEscape( workingDirectory.getPath(), '"' ) );
+                         + " -- ." );
     }
 
     public void testCommandLineWithStartVersionAndEndVersionEquals()
@@ -148,7 +148,7 @@ public class GitChangeLogCommandTest
     {
         testCommandLine( "scm:git:http://foo.com/git", null, new ScmRevision( "1" ), new ScmRevision( "1" ), 
                          "git whatchanged --date=iso 1..1"
-                         + " -- " + StringUtils.quoteAndEscape( workingDirectory.getPath(), '"' ) );
+                         + " -- ." );
     }
 
     public void testCommandLineWithStartVersionAndEndVersionAndBranch()
@@ -156,7 +156,7 @@ public class GitChangeLogCommandTest
     {
         testCommandLine( "scm:git:http://foo.com/git", new ScmBranch( "my-test-branch" ), new ScmRevision( "1" ), new ScmRevision( "10" ), 
                          "git whatchanged --date=iso 1..10 my-test-branch"
-                         + " -- " + StringUtils.quoteAndEscape( workingDirectory.getPath(), '"' ) );
+                         + " -- ." );
     }
 
     // ----------------------------------------------------------------------

--- a/maven-scm-providers/maven-scm-providers-git/maven-scm-provider-gitexe/src/test/java/org/apache/maven/scm/provider/git/gitexe/command/checkin/GitCheckInCommandNoBranchTest.java
+++ b/maven-scm-providers/maven-scm-providers-git/maven-scm-provider-gitexe/src/test/java/org/apache/maven/scm/provider/git/gitexe/command/checkin/GitCheckInCommandNoBranchTest.java
@@ -61,7 +61,7 @@ public class GitCheckInCommandNoBranchTest
         FileUtils.deleteDirectory( repo );
         FileUtils.copyDirectoryStructure( repo_orig, repo );
 
-        ScmRepository scmRepository = getScmManager().makeScmRepository( "scm:git:file:///" + repo.getAbsolutePath() );
+        ScmRepository scmRepository = getScmManager().makeScmRepository( "scm:git:" + repo.toPath().toUri().toASCIIString() );
 
         CheckOutScmResult checkOutScmResult = checkoutRepo( scmRepository );
 

--- a/maven-scm-providers/maven-scm-providers-git/maven-scm-provider-gitexe/src/test/java/org/apache/maven/scm/provider/git/gitexe/command/checkin/GitCheckInCommandTest.java
+++ b/maven-scm-providers/maven-scm-providers-git/maven-scm-provider-gitexe/src/test/java/org/apache/maven/scm/provider/git/gitexe/command/checkin/GitCheckInCommandTest.java
@@ -65,7 +65,7 @@ public class GitCheckInCommandTest
     {
         if ( GitUtil.getSettings().isCommitNoVerify() )
         {
-            testCommandLine( "scm:git:http://foo.com/git/trunk", "git commit --verbose " + messageFileString + " -a" + " --no-verify" );    
+            testCommandLine( "scm:git:http://foo.com/git/trunk", "git commit --verbose " + messageFileString + " -a" + " --no-verify" );
         }
         else
         {
@@ -95,18 +95,18 @@ public class GitCheckInCommandTest
 
         GitScmTestUtils.initRepo("src/test/resources/repository/", getRepositoryRoot(), getWorkingDirectory());
 
-        ScmRepository scmRepository = getScmManager().makeScmRepository( "scm:git:file://" + repo.getAbsolutePath() );
+        ScmRepository scmRepository = getScmManager().makeScmRepository( "scm:git:" + repo.toPath().toUri().toASCIIString() );
         checkoutRepoInto(checkedOutRepo, scmRepository);
 
         // Add a default user to the config
         GitScmTestUtils.setDefaultUser( checkedOutRepo );
 
         // Creating foo/bar/wine.xml
-        File fooDir = new File( checkedOutRepo.getAbsolutePath() + File.separator + "foo" );
+        File fooDir = new File( checkedOutRepo.getAbsolutePath(), "foo" );
         fooDir.mkdir();
-        File barDir = new File(fooDir.getAbsolutePath() + File.separator + "bar");
+        File barDir = new File(fooDir.getAbsolutePath(), "bar");
         barDir.mkdir();
-        File wineFile = new File(barDir.getAbsolutePath() + File.separator + "wine.xml");
+        File wineFile = new File(barDir.getAbsolutePath(), "wine.xml");
         FileUtils.fileWrite( wineFile.getAbsolutePath(), "Lacoste castle" );
 
         // Adding and commiting file
@@ -116,9 +116,9 @@ public class GitCheckInCommandTest
         assertResultIsSuccess( checkInScmResult );
 
         // Cloning foo/bar/wine.xml to foo/newbar/wine.xml
-        File newBarDir = new File(fooDir.getAbsolutePath() + File.separator + "newbar");
+        File newBarDir = new File(fooDir.getAbsolutePath(), "newbar");
         newBarDir.mkdir();
-        File movedWineFile = new File(newBarDir.getAbsolutePath() + File.separator + "wine.xml");
+        File movedWineFile = new File(newBarDir.getAbsolutePath(), "wine.xml");
         FileUtils.copyFile(wineFile, movedWineFile);
 
         // Removing old file, adding new file and commiting...

--- a/maven-scm-providers/maven-scm-providers-git/maven-scm-provider-gitexe/src/test/java/org/apache/maven/scm/provider/git/gitexe/command/checkout/GitExeCheckOutCommandNoBranchTest.java
+++ b/maven-scm-providers/maven-scm-providers-git/maven-scm-provider-gitexe/src/test/java/org/apache/maven/scm/provider/git/gitexe/command/checkout/GitExeCheckOutCommandNoBranchTest.java
@@ -50,7 +50,7 @@ public class GitExeCheckOutCommandNoBranchTest
         FileUtils.deleteDirectory( workingDirectory );
         repo = new File( "src/test/resources/repository_no_branch" );
 
-        scmRepository = getScmManager().makeScmRepository( "scm:git:file:///" + repo.getAbsolutePath() );
+        scmRepository = getScmManager().makeScmRepository( "scm:git:" + repo.toPath().toUri().toASCIIString() );
     }
 
     public void testCheckoutNoBranch()

--- a/maven-scm-providers/maven-scm-providers-git/maven-scm-provider-gitexe/src/test/java/org/apache/maven/scm/provider/git/gitexe/command/info/GitInfoCommandTckTest.java
+++ b/maven-scm-providers/maven-scm-providers-git/maven-scm-provider-gitexe/src/test/java/org/apache/maven/scm/provider/git/gitexe/command/info/GitInfoCommandTckTest.java
@@ -50,7 +50,7 @@ public class GitInfoCommandTckTest
             provider.info( repository, new ScmFileSet( getRepositoryRoot() ), new CommandParameters() );
         assertNotNull( result );
         assertEquals( "cd3c0dfacb65955e6fbb35c56cc5b1bf8ce4f767", result.getInfoItems().get( 0 ).getRevision() );
-        // 
+        //
     }
 
     public void testInfoCommandWithShortRevision()

--- a/maven-scm-providers/maven-scm-providers-git/maven-scm-provider-gittest/src/main/java/org/apache/maven/scm/provider/git/GitScmTestUtils.java
+++ b/maven-scm-providers/maven-scm-providers-git/maven-scm-provider-gittest/src/main/java/org/apache/maven/scm/provider/git/GitScmTestUtils.java
@@ -19,18 +19,15 @@ package org.apache.maven.scm.provider.git;
  * under the License.
  */
 
-import junit.framework.Assert;
-import org.codehaus.plexus.PlexusTestCase;
-import org.codehaus.plexus.util.FileUtils;
-import org.codehaus.plexus.util.Os;
-import org.codehaus.plexus.util.StringUtils;
-import org.codehaus.plexus.util.cli.CommandLineException;
-import org.codehaus.plexus.util.cli.CommandLineUtils;
-import org.codehaus.plexus.util.cli.Commandline;
-
 import java.io.File;
 import java.io.FileWriter;
 import java.io.IOException;
+
+import junit.framework.Assert;
+
+import org.codehaus.plexus.PlexusTestCase;
+import org.codehaus.plexus.util.FileUtils;
+import org.codehaus.plexus.util.cli.CommandLineException;
 
 /**
  * @author <a href="mailto:trygvis@inamo.no">Trygve Laugst&oslash;l</a>
@@ -79,37 +76,7 @@ public final class GitScmTestUtils
     public static String getScmUrl( File repositoryRootFile, String provider )
         throws CommandLineException
     {
-        String repositoryRoot = repositoryRootFile.getAbsolutePath();
-
-        // TODO: it'd be great to build this into CommandLineUtils somehow
-        // TODO: some way without a custom cygwin sys property?
-        if ( "true".equals( System.getProperty( "cygwin" ) ) )
-        {
-            Commandline cl = new Commandline();
-
-            cl.setExecutable( "cygpath" );
-
-            cl.createArg().setValue( "--unix" );
-
-            cl.createArg().setValue( repositoryRoot );
-
-            CommandLineUtils.StringStreamConsumer stdout = new CommandLineUtils.StringStreamConsumer();
-
-            int exitValue = CommandLineUtils.executeCommandLine( cl, stdout, null );
-
-            if ( exitValue != 0 )
-            {
-                throw new CommandLineException( "Unable to convert cygwin path, exit code = " + exitValue );
-            }
-
-            repositoryRoot = stdout.getOutput().trim();
-        }
-        else if ( Os.isFamily( "windows" ) )
-        {
-            repositoryRoot = "/" + StringUtils.replace( repositoryRoot, "\\", "/" );
-        }
-
-        return "scm:" + provider + ":file://" + repositoryRoot;
+        return "scm:" + provider + ":" + repositoryRootFile.toPath().toUri().toASCIIString();
     }
 
 

--- a/maven-scm-providers/maven-scm-providers-git/maven-scm-provider-gittest/src/main/java/org/apache/maven/scm/provider/git/command/changelog/GitChangeLogCommandTckTest.java
+++ b/maven-scm-providers/maven-scm-providers-git/maven-scm-provider-gittest/src/main/java/org/apache/maven/scm/provider/git/command/changelog/GitChangeLogCommandTckTest.java
@@ -48,7 +48,7 @@ public abstract class GitChangeLogCommandTckTest
     public void initRepo()
         throws Exception
     {
-        GitScmTestUtils.initRepo( "src/test/resources/linear-changelog/", getRepositoryRoot(), getWorkingDirectory() );
+        GitScmTestUtils.initRepo( "src/test/resources/linear-changelog/", getRepositoryRoot(), getWorkingCopy() );
     }
 
     @Override

--- a/maven-scm-providers/maven-scm-providers-git/maven-scm-provider-gittest/src/main/java/org/apache/maven/scm/provider/git/command/update/GitUpdateCommandTckTest.java
+++ b/maven-scm-providers/maven-scm-providers-git/maven-scm-provider-gittest/src/main/java/org/apache/maven/scm/provider/git/command/update/GitUpdateCommandTckTest.java
@@ -37,7 +37,7 @@ public abstract class GitUpdateCommandTckTest
     public void initRepo()
         throws Exception
     {
-        GitScmTestUtils.initRepo( "src/test/resources/repository/", getRepositoryRoot(), getWorkingDirectory() );
+        GitScmTestUtils.initRepo( "src/test/resources/repository/", getRepositoryRoot(), getWorkingCopy() );
     }
 
     @Override

--- a/maven-scm-providers/maven-scm-providers-git/maven-scm-provider-jgit/src/main/java/org/apache/maven/scm/provider/git/jgit/command/info/JGitInfoCommand.java
+++ b/maven-scm-providers/maven-scm-providers-git/maven-scm-provider-jgit/src/main/java/org/apache/maven/scm/provider/git/jgit/command/info/JGitInfoCommand.java
@@ -60,7 +60,7 @@ public class JGitInfoCommand
 
             InfoItem infoItem = new InfoItem();
             infoItem.setRevision( StringUtils.trim( objectId.name() ) );
-            infoItem.setURL( basedir.getPath() );
+            infoItem.setURL( basedir.toPath().toUri().toASCIIString() );
 
             return new InfoScmResult( Collections.singletonList( infoItem ),
                                       new ScmResult( "JGit.resolve(HEAD)", "", objectId.toString(), true ) );

--- a/maven-scm-providers/maven-scm-providers-svn/maven-scm-provider-svntest/src/main/java/org/apache/maven/scm/provider/svn/SvnScmTestUtils.java
+++ b/maven-scm-providers/maven-scm-providers-svn/maven-scm-provider-svntest/src/main/java/org/apache/maven/scm/provider/svn/SvnScmTestUtils.java
@@ -22,7 +22,6 @@ package org.apache.maven.scm.provider.svn;
 import junit.framework.Assert;
 import org.apache.maven.scm.ScmTestCase;
 import org.codehaus.plexus.util.FileUtils;
-import org.codehaus.plexus.util.Os;
 import org.codehaus.plexus.util.StringUtils;
 import org.codehaus.plexus.util.cli.CommandLineException;
 import org.codehaus.plexus.util.cli.CommandLineUtils;
@@ -55,7 +54,7 @@ public final class SvnScmTestUtils
         {
             FileUtils.deleteDirectory( repositoryRoot );
         }
-        
+
         Assert.assertFalse( "repositoryRoot still exists", repositoryRoot.exists() );
 
         Assert.assertTrue( "Could not make repository root directory: " + repositoryRoot.getAbsolutePath(),
@@ -132,36 +131,6 @@ public final class SvnScmTestUtils
     public static String getScmUrl( File repositoryRootFile )
         throws CommandLineException
     {
-        String repositoryRoot = repositoryRootFile.getAbsolutePath();
-
-        // TODO: it'd be great to build this into CommandLineUtils somehow
-        // TODO: some way without a custom cygwin sys property?
-        if ( "true".equals( System.getProperty( "cygwin" ) ) )
-        {
-            Commandline cl = new Commandline();
-
-            cl.setExecutable( "cygpath" );
-
-            cl.createArg().setValue( "--unix" );
-
-            cl.createArg().setValue( repositoryRoot );
-
-            CommandLineUtils.StringStreamConsumer stdout = new CommandLineUtils.StringStreamConsumer();
-
-            int exitValue = CommandLineUtils.executeCommandLine( cl, stdout, null );
-
-            if ( exitValue != 0 )
-            {
-                throw new CommandLineException( "Unable to convert cygwin path, exit code = " + exitValue );
-            }
-
-            repositoryRoot = stdout.getOutput().trim();
-        }
-        else if ( Os.isFamily( "windows" ) )
-        {
-            repositoryRoot = "/" + StringUtils.replace( repositoryRoot, "\\", "/" );
-        }
-
-        return "scm:svn:file://" + repositoryRoot;
+        return "scm:svn:" + repositoryRootFile.toPath().toUri().toASCIIString();
     }
 }


### PR DESCRIPTION
Cygwin: use relative path for checkout directory
Cygwin: force forward slashes in commands
Git for Windows: fix file://\\unc\path does not appear to be a git repository