### PR TITLE
Clear warnings

### DIFF
--- a/maven-scm-api/src/main/java/org/apache/maven/scm/ScmFileSet.java
+++ b/maven-scm-api/src/main/java/org/apache/maven/scm/ScmFileSet.java
@@ -102,8 +102,7 @@ public class ScmFileSet
         {
             excludes = DEFAULT_EXCLUDES;
         }
-        @SuppressWarnings( "unchecked" )
-        List<File> fileList = (List<File>) FileUtils.getFiles( basedir, includes, excludes, false ); 
+        List<File> fileList = FileUtils.getFiles( basedir, includes, excludes, false ); 
         this.files = fileList;
         this.includes = includes;
         this.excludes = excludes;

--- a/maven-scm-api/src/test/java/org/apache/maven/scm/ScmResultTest.java
+++ b/maven-scm-api/src/test/java/org/apache/maven/scm/ScmResultTest.java
@@ -20,7 +20,6 @@ package org.apache.maven.scm;
  */
 
 import junit.framework.TestCase;
-import org.apache.maven.scm.provider.ScmUrlUtils;
 
 public class ScmResultTest
     extends TestCase

--- a/maven-scm-providers/maven-scm-provider-accurev/src/test/java/org/apache/maven/scm/CollectionSizeMatcher.java
+++ b/maven-scm-providers/maven-scm-provider-accurev/src/test/java/org/apache/maven/scm/CollectionSizeMatcher.java
@@ -39,7 +39,7 @@ public class CollectionSizeMatcher<T>
     @Override
     public boolean matchesSafely( Iterable<T> iterable )
     {
-        Collection collection = (Collection) iterable;
+        Collection<?> collection = (Collection<?>) iterable;
         return collection.size() == this.size;
 
     }

--- a/maven-scm-providers/maven-scm-provider-clearcase/src/test/java/org/apache/maven/scm/provider/clearcase/command/checkin/ClearCaseCheckInCommandTest.java
+++ b/maven-scm-providers/maven-scm-provider-clearcase/src/test/java/org/apache/maven/scm/provider/clearcase/command/checkin/ClearCaseCheckInCommandTest.java
@@ -19,7 +19,6 @@ package org.apache.maven.scm.provider.clearcase.command.checkin;
  * under the License.
  */
 
-import org.apache.maven.scm.ScmException;
 import org.apache.maven.scm.ScmFileSet;
 import org.apache.maven.scm.ScmTestCase;
 import org.codehaus.plexus.util.cli.Commandline;

--- a/maven-scm-providers/maven-scm-provider-jazz/src/test/java/org/apache/maven/scm/provider/jazz/command/JazzScmCommandTest.java
+++ b/maven-scm-providers/maven-scm-provider-jazz/src/test/java/org/apache/maven/scm/provider/jazz/command/JazzScmCommandTest.java
@@ -5,7 +5,6 @@ import static org.junit.Assert.assertNotEquals;
 import org.apache.maven.scm.ScmFileSet;
 import org.apache.maven.scm.provider.jazz.JazzScmTestCase;
 import org.codehaus.plexus.util.Os;
-import org.codehaus.plexus.util.cli.Commandline;
 
 /*
  * Licensed to the Apache Software Foundation (ASF) under one

--- a/maven-scm-providers/maven-scm-provider-jazz/src/test/java/org/apache/maven/scm/provider/jazz/command/checkin/JazzCheckInCommandTest.java
+++ b/maven-scm-providers/maven-scm-provider-jazz/src/test/java/org/apache/maven/scm/provider/jazz/command/checkin/JazzCheckInCommandTest.java
@@ -1,7 +1,5 @@
 package org.apache.maven.scm.provider.jazz.command.checkin;
 
-import java.awt.List;
-
 import org.apache.maven.scm.ScmFileSet;
 import org.apache.maven.scm.log.DefaultLog;
 import org.apache.maven.scm.provider.jazz.JazzScmTestCase;

--- a/maven-scm-providers/maven-scm-providers-git/maven-scm-provider-gitexe/src/test/java/org/apache/maven/scm/provider/git/gitexe/command/checkout/GitExeCheckOutCommandNoBranchTest.java
+++ b/maven-scm-providers/maven-scm-providers-git/maven-scm-provider-gitexe/src/test/java/org/apache/maven/scm/provider/git/gitexe/command/checkout/GitExeCheckOutCommandNoBranchTest.java
@@ -25,7 +25,6 @@ import org.apache.maven.scm.ScmVersion;
 import org.apache.maven.scm.command.checkout.CheckOutScmResult;
 import org.apache.maven.scm.repository.ScmRepository;
 import org.codehaus.plexus.util.FileUtils;
-import org.codehaus.plexus.util.Os;
 
 import java.io.File;
 

--- a/maven-scm-providers/maven-scm-providers-git/maven-scm-provider-gitexe/src/test/java/org/apache/maven/scm/provider/git/gitexe/command/info/GitInfoCommandTckTest.java
+++ b/maven-scm-providers/maven-scm-providers-git/maven-scm-provider-gitexe/src/test/java/org/apache/maven/scm/provider/git/gitexe/command/info/GitInfoCommandTckTest.java
@@ -28,7 +28,6 @@ import org.apache.maven.scm.provider.ScmProvider;
 import org.apache.maven.scm.provider.ScmProviderRepository;
 import org.apache.maven.scm.provider.git.GitScmTestUtils;
 import org.codehaus.plexus.PlexusTestCase;
-import org.codehaus.plexus.util.FileUtils;
 
 import java.io.File;
 

--- a/maven-scm-providers/maven-scm-providers-svn/maven-scm-provider-svnexe/src/main/java/org/apache/maven/scm/provider/svn/svnexe/command/branch/SvnBranchCommand.java
+++ b/maven-scm-providers/maven-scm-providers-svn/maven-scm-provider-svnexe/src/main/java/org/apache/maven/scm/provider/svn/svnexe/command/branch/SvnBranchCommand.java
@@ -39,7 +39,6 @@ import org.apache.maven.scm.provider.svn.SvnTagBranchUtils;
 import org.apache.maven.scm.provider.svn.command.SvnCommand;
 import org.apache.maven.scm.provider.svn.repository.SvnScmProviderRepository;
 import org.apache.maven.scm.provider.svn.svnexe.command.SvnCommandLineUtils;
-import org.apache.maven.scm.provider.svn.util.SvnUtil;
 import org.codehaus.plexus.util.FileUtils;
 import org.codehaus.plexus.util.Os;
 import org.codehaus.plexus.util.StringUtils;
@@ -136,7 +135,6 @@ public class SvnBranchCommand
 
         try
         {
-            @SuppressWarnings( "unchecked" )
             List<File> listFiles = FileUtils.getFiles( fileSet.getBasedir(), "**", "**/.svn/**", false );
             files = listFiles;
         }

--- a/maven-scm-providers/maven-scm-providers-svn/maven-scm-provider-svnexe/src/test/java/org/apache/maven/scm/provider/svn/svnexe/command/changelog/SvnChangeLogConsumerTest.java
+++ b/maven-scm-providers/maven-scm-providers-svn/maven-scm-provider-svnexe/src/test/java/org/apache/maven/scm/provider/svn/svnexe/command/changelog/SvnChangeLogConsumerTest.java
@@ -83,7 +83,7 @@ public class SvnChangeLogConsumerTest
 
         final ChangeSet entry = consumer.getModifications().get( 0 );
 
-        final List changedFiles = entry.getFiles();
+        final List<ChangeFile> changedFiles = entry.getFiles();
         final String revision = ( (ChangeFile) changedFiles.get( 0 ) ).getRevision();
 
         assertEquals( "Valid revision expected", "15", revision );
@@ -237,7 +237,7 @@ public class SvnChangeLogConsumerTest
             consumer.consumeLine( line );
         }
 
-        List modifications = consumer.getModifications();
+        List<ChangeSet> modifications = consumer.getModifications();
 
         out.append( "nb modifications : " + modifications.size() );
 

--- a/maven-scm-providers/maven-scm-providers-svn/maven-scm-provider-svnexe/src/test/java/org/apache/maven/scm/provider/svn/svnexe/command/checkout/SvnCheckOutCommandTest.java
+++ b/maven-scm-providers/maven-scm-providers-svn/maven-scm-provider-svnexe/src/test/java/org/apache/maven/scm/provider/svn/svnexe/command/checkout/SvnCheckOutCommandTest.java
@@ -106,7 +106,6 @@ public class SvnCheckOutCommandTest
         SvnScmProviderRepository svnRepository = (SvnScmProviderRepository) repository.getProviderRepository();
 
         Commandline cl =
-            cl =
                 SvnCheckOutCommand.createCommandLine( svnRepository, workingDirectory,
                                                       new ScmRevision( revision ), svnRepository.getUrl(),
                                                       recursive );


### PR DESCRIPTION
some easy and hopefully useful cleanups:
- introducing `ConsumerUtils`, to close reader as soon as possible and to remove some duplications
-  raw types
-  unused imports
