### PR TITLE
[SCM-928] added scm type 'mount-repos' to support google repo tool for checkout manifest.xml

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ target
 build
 .idea
 .java-version
+.checkstyle
 nbactions.xml
 maven-scm-providers/maven-scm-providers-cvs/maven-scm-provider-cvsexe/src/test/repository/CVSROOT/history
 maven-scm-providers/maven-scm-providers-cvs/maven-scm-provider-cvsjava/src/test/repository/CVSROOT/history

--- a/maven-scm-plugin/pom.xml
+++ b/maven-scm-plugin/pom.xml
@@ -85,6 +85,10 @@
       <groupId>org.apache.maven.scm</groupId>
       <artifactId>maven-scm-provider-svn-commons</artifactId>
     </dependency>
+    <dependency>
+      <groupId>org.apache.maven.scm</groupId>
+      <artifactId>maven-scm-provider-mountrepos</artifactId>
+    </dependency>
     <!-- end providers declaration -->
 
     <dependency>

--- a/maven-scm-plugin/src/main/java/org/apache/maven/scm/plugin/CheckoutOrUpdateMojo.java
+++ b/maven-scm-plugin/src/main/java/org/apache/maven/scm/plugin/CheckoutOrUpdateMojo.java
@@ -1,0 +1,190 @@
+package org.apache.maven.scm.plugin;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.plugins.annotations.Mojo;
+import org.apache.maven.plugins.annotations.Parameter;
+import org.apache.maven.scm.ScmException;
+import org.apache.maven.scm.ScmFile;
+import org.apache.maven.scm.ScmFileSet;
+import org.apache.maven.scm.ScmResult;
+import org.apache.maven.scm.ScmVersion;
+import org.apache.maven.scm.command.checkout.CheckOutScmResult;
+import org.apache.maven.scm.provider.ScmProvider;
+import org.apache.maven.scm.provider.ScmProviderRepository;
+import org.apache.maven.scm.provider.mountrepos.MountReposScmProviderRepository;
+import org.apache.maven.scm.provider.mountrepos.MountReposScmProviderRepository.MountProjectRepository;
+import org.apache.maven.scm.repository.ScmRepository;
+
+/**
+ * checkout or update
+ */
+@Mojo( name = "checkout-or-update", requiresProject = false )
+public class CheckoutOrUpdateMojo
+    extends AbstractScmMojo
+{
+
+    /**
+     * The directory to checkout the sources to for the bootstrap and checkout goals.
+     */
+    @Parameter( property = "checkoutDirectory", defaultValue = "${project.build.directory}/checkout" )
+    private File checkoutDirectory;
+
+    /**
+     * The version type (branch/tag/revision) of scmVersion.
+     */
+    @Parameter( property = "scmVersionType" )
+    private String scmVersionType;
+
+    /**
+     * The version (revision number/branch name/tag name).
+     */
+    @Parameter( property = "scmVersion" )
+    private String scmVersion;
+
+    /**
+     * result of checkout
+     */
+    private ScmResult checkoutResult;
+
+    /** {@inheritDoc} */
+    public void execute()
+        throws MojoExecutionException
+    {
+        super.execute();
+
+        if ( this.checkoutDirectory.getPath().contains( "${project.basedir}" ) )
+        {
+            //project.basedir is not set under maven 3.x when run without a project
+            this.checkoutDirectory = new File( this.getBasedir(), "target/checkout" );
+        }
+        if ( ! this.checkoutDirectory.exists() )
+        {
+            if ( !this.checkoutDirectory.mkdirs() )
+            {
+                throw new MojoExecutionException( "Cannot create " + this.checkoutDirectory );
+            }
+        }
+
+        try
+        {
+            ScmRepository repository = getScmRepository();
+            ScmProviderRepository scmRepository = repository.getProviderRepository();
+
+            ScmResult result = null;
+
+            boolean alreadyCheckout = false;
+            ScmProvider scmProvider = getScmManager().getProviderByRepository( repository );
+            String scmSpecificFilename = scmProvider.getScmSpecificFilename();
+            if ( scmSpecificFilename != null )
+            {
+                File scmSpecificFile = new File( checkoutDirectory.getAbsoluteFile(), scmSpecificFilename);
+                alreadyCheckout = scmSpecificFile.exists();
+            }
+
+            if ( ! alreadyCheckout && scmRepository instanceof MountReposScmProviderRepository )
+            {
+                result = updateOrCheckoutMulti( (MountReposScmProviderRepository) scmRepository );
+            }
+            else
+            {
+                ScmFileSet fileSet = new ScmFileSet( checkoutDirectory.getAbsoluteFile() );
+                if ( alreadyCheckout )
+                {
+                    result = getScmManager().update( repository, fileSet );
+                }
+                else
+                {
+                    result = getScmManager().checkOut( repository, fileSet, getScmVersion( scmVersionType, scmVersion ) );
+                }
+
+                checkResult( result );
+            }
+
+            handleExcludesIncludesAfterCheckoutAndExport( this.checkoutDirectory );
+            this.checkoutResult = result;
+        }
+        catch ( ScmException e )
+        {
+            throw new MojoExecutionException( "Cannot run checkout command : ", e );
+        }
+    }
+
+    private CheckOutScmResult updateOrCheckoutMulti( MountReposScmProviderRepository mountRepos )
+            throws MojoExecutionException
+    {
+        ScmVersion scmVersionObj = getScmVersion( scmVersionType, scmVersion );
+        boolean recursive = true; // parameters.getBoolean( CommandParameter.RECURSIVE, true );
+        // boolean shallow = parameters.getBoolean( CommandParameter.SHALLOW, false );
+
+        List<String> failedProjectNames = new ArrayList<>();
+        StringBuilder exceptionsMessage = new StringBuilder();
+
+        List<ScmFile> checkedOutFiles = new ArrayList<ScmFile>();
+        for (MountProjectRepository mountProject : mountRepos.getProjectScmProviderRepositories().values())
+        {
+            ScmRepository mountScmRepository = mountProject.getScmRepository();
+            ScmVersion mountScmVersionObj = getScmVersion( "branch", mountProject.getRevision() );
+
+            ScmFileSet mountScmFileSet = new ScmFileSet( new File( checkoutDirectory, mountProject.getPath() ) );
+
+            try
+            {
+                CheckOutScmResult mountRes = getScmManager().checkOut(mountScmRepository, mountScmFileSet, mountScmVersionObj, recursive );
+
+                checkedOutFiles.addAll( mountRes.getCheckedOutFiles() );
+            }
+            catch( Exception ex )
+            {
+                failedProjectNames.add( mountProject.getRepoProject().getName() );
+                exceptionsMessage.append( ex.getMessage() + " project='" + mountProject.getRepoProject().getName() + "' in path='" + mountProject.getPath() + "'\n" );
+            }
+        }
+        if ( ! failedProjectNames.isEmpty() )
+        {
+            throw new MojoExecutionException( "Failed to checkout " + failedProjectNames.size() + " sub project(s) "
+                    + failedProjectNames
+                    + " exceptions: " + exceptionsMessage);
+        }
+
+        return new CheckOutScmResult( "repo update", scmVersion, checkedOutFiles );
+    }
+
+    protected File getCheckoutDirectory()
+    {
+        return this.checkoutDirectory;
+    }
+
+    public void setCheckoutDirectory( File checkoutDirectory )
+    {
+        this.checkoutDirectory = checkoutDirectory;
+    }
+
+    protected ScmResult getCheckoutResult()
+    {
+        return checkoutResult;
+    }
+
+}

--- a/maven-scm-providers/maven-scm-provider-mountrepos/pom.xml
+++ b/maven-scm-providers/maven-scm-provider-mountrepos/pom.xml
@@ -1,0 +1,112 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one
+  ~ or more contributor license agreements.  See the NOTICE file
+  ~ distributed with this work for additional information
+  ~ regarding copyright ownership.  The ASF licenses this file
+  ~ to you under the Apache License, Version 2.0 (the
+  ~ "License"); you may not use this file except in compliance
+  ~ with the License.  You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing,
+  ~ software distributed under the License is distributed on an
+  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  ~ KIND, either express or implied.  See the License for the
+  ~ specific language governing permissions and limitations
+  ~ under the License.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <artifactId>maven-scm-providers</artifactId>
+    <groupId>org.apache.maven.scm</groupId>
+    <version>1.11.3-SNAPSHOT</version>
+  </parent>
+
+  <artifactId>maven-scm-provider-mountrepos</artifactId>
+  <packaging>jar</packaging>
+
+  <name>Maven SCM Mount multi Repositories Provider</name>
+  <description>SCM Provider implementation for mounting multi repositories (https://gerrit.googlesource.com/git-repo/).</description>
+
+  <dependencies>
+    <dependency>
+        <groupId>org.apache.maven.scm</groupId>
+        <artifactId>maven-scm-provider-jgit</artifactId>
+        <version>${project.version}</version>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.codehaus.modello</groupId>
+        <artifactId>modello-maven-plugin</artifactId>
+        <version>1.10.0</version>
+        <executions>
+          <execution>
+            <id>generate-xsd-site</id>
+            <phase>pre-site</phase>
+            <goals>
+              <goal>xsd</goal>
+            </goals>
+            <configuration>
+              <outputDirectory>${project.reporting.outputDirectory}/xsd</outputDirectory>
+            </configuration>
+          </execution>
+          <execution>
+            <id>site-docs</id>
+            <phase>pre-site</phase>
+            <goals>
+              <goal>xdoc</goal>
+            </goals>
+          </execution>
+          <execution>
+            <id>standard</id>
+            <goals>
+              <goal>java</goal>
+              <goal>xpp3-reader</goal>
+              <goal>xpp3-writer</goal>
+              <goal>xsd</goal>
+            </goals>
+          </execution>
+        </executions>
+        <configuration>
+          <version>1.11.3</version>
+          <models>
+            <model>src/main/mdo/manifest.mdo</model>
+          </models>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.codehaus.plexus</groupId>
+        <artifactId>plexus-component-metadata</artifactId>
+        <executions>
+          <execution>
+            <id>create-component-descriptor</id>
+            <phase>generate-resources</phase>
+            <goals>
+              <goal>generate-metadata</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.rat</groupId>
+        <artifactId>apache-rat-plugin</artifactId>
+        <configuration>
+          <excludes>
+            <exclude>src/main/mdo/manifest.dtd</exclude>
+          </excludes>
+        </configuration>
+      </plugin>
+      
+    </plugins>
+  </build>
+
+</project>

--- a/maven-scm-providers/maven-scm-provider-mountrepos/src/main/java/org/apache/maven/scm/provider/mountrepos/MountReposScmProvider.java
+++ b/maven-scm-providers/maven-scm-provider-mountrepos/src/main/java/org/apache/maven/scm/provider/mountrepos/MountReposScmProvider.java
@@ -1,0 +1,687 @@
+package org.apache.maven.scm.provider.mountrepos;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.Reader;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.apache.maven.scm.CommandParameter;
+import org.apache.maven.scm.CommandParameters;
+import org.apache.maven.scm.ScmBranch;
+import org.apache.maven.scm.ScmBranchParameters;
+import org.apache.maven.scm.ScmException;
+import org.apache.maven.scm.ScmFile;
+import org.apache.maven.scm.ScmFileSet;
+import org.apache.maven.scm.ScmTagParameters;
+import org.apache.maven.scm.ScmVersion;
+import org.apache.maven.scm.command.add.AddScmResult;
+import org.apache.maven.scm.command.blame.BlameScmRequest;
+import org.apache.maven.scm.command.blame.BlameScmResult;
+import org.apache.maven.scm.command.branch.BranchScmResult;
+import org.apache.maven.scm.command.changelog.ChangeLogScmRequest;
+import org.apache.maven.scm.command.changelog.ChangeLogScmResult;
+import org.apache.maven.scm.command.checkin.CheckInScmResult;
+import org.apache.maven.scm.command.checkout.CheckOutScmResult;
+import org.apache.maven.scm.command.diff.DiffScmResult;
+import org.apache.maven.scm.command.edit.EditScmResult;
+import org.apache.maven.scm.command.export.ExportScmResult;
+import org.apache.maven.scm.command.info.InfoScmResult;
+import org.apache.maven.scm.command.list.ListScmResult;
+import org.apache.maven.scm.command.mkdir.MkdirScmResult;
+import org.apache.maven.scm.command.remoteinfo.RemoteInfoScmResult;
+import org.apache.maven.scm.command.remove.RemoveScmResult;
+import org.apache.maven.scm.command.status.StatusScmResult;
+import org.apache.maven.scm.command.tag.TagScmResult;
+import org.apache.maven.scm.command.unedit.UnEditScmResult;
+import org.apache.maven.scm.command.untag.UntagScmResult;
+import org.apache.maven.scm.command.update.UpdateScmResult;
+import org.apache.maven.scm.manager.ScmManager;
+import org.apache.maven.scm.provider.AbstractScmProvider;
+import org.apache.maven.scm.provider.ScmProviderRepository;
+import org.apache.maven.scm.provider.git.jgit.JGitScmProvider;
+import org.apache.maven.scm.provider.mountrepos.MountReposScmProviderRepository.MountProjectRepository;
+import org.apache.maven.scm.providers.mountrepos.manifest.MountReposManifest;
+import org.apache.maven.scm.providers.mountrepos.manifest.io.xpp3.MountReposManifestXpp3Reader;
+import org.apache.maven.scm.repository.ScmRepository;
+import org.apache.maven.scm.repository.ScmRepositoryException;
+import org.apache.maven.scm.repository.UnknownRepositoryStructure;
+import org.codehaus.plexus.util.FileUtils;
+import org.codehaus.plexus.util.xml.pull.XmlPullParserException;
+
+/**
+ * @plexus.component role="org.apache.maven.scm.provider.ScmProvider" role-hint="mount-repos"
+ * @since 1.11
+ */
+public class MountReposScmProvider
+    extends AbstractScmProvider
+{
+
+    public static final String REPO_DIRNAME = ".repo";
+
+    /**
+     * @plexus.requirement role="org.apache.maven.scm.manager.ScmManager"
+     */
+    private ScmManager scmManager;
+
+    /**
+     * @plexus.requirement role="org.apache.maven.scm.provider.ScmProvider" role-hint="jgit"
+     */
+    protected JGitScmProvider gitScmProvider;
+
+    @Override
+    public String getScmType()
+    {
+        return "mount-repos";
+    }
+
+    @Override
+    public ScmProviderRepository makeProviderScmRepository( String scmSpecificUrl, char delimiter )
+        throws ScmRepositoryException
+    {
+        if ( scmSpecificUrl == null )
+        {
+            throw new ScmRepositoryException( "url must not be null" );
+        }
+        File repoManifestFile = new File( scmSpecificUrl );
+        if ( !repoManifestFile.exists() )
+        {
+            throw new ScmRepositoryException( "manifest file not found '" + repoManifestFile.getAbsolutePath() + "'" );
+        }
+        MountReposManifest reposManifest = parseReposManifest( repoManifestFile );
+        return new MountReposScmProviderRepository( repoManifestFile, reposManifest, scmManager );
+    }
+
+    @Override
+    public ScmProviderRepository makeProviderScmRepository( File path )
+        throws ScmRepositoryException, UnknownRepositoryStructure
+    {
+        File manifestFile = new File( path, REPO_DIRNAME + "/defaut.xml" );
+        if ( !manifestFile.exists() )
+        {
+            throw new ScmRepositoryException( "manifest file not found '" + manifestFile.getAbsolutePath() + "'" );
+        }
+        MountReposManifest reposManifest = parseReposManifest( manifestFile );
+        return new MountReposScmProviderRepository( manifestFile, reposManifest, scmManager );
+    }
+
+    private MountReposManifest parseReposManifest( File repoManifestFile )
+        throws ScmRepositoryException
+    {
+        MountReposManifestXpp3Reader reader = new MountReposManifestXpp3Reader();
+        Reader fileReader = null;
+        try
+        {
+            fileReader = new InputStreamReader( new FileInputStream( repoManifestFile ) );
+            return reader.read( fileReader, false );
+        }
+        catch ( IOException | XmlPullParserException ex )
+        {
+            throw new ScmRepositoryException( "Failed to parse repos manifest xml file '"
+                + repoManifestFile.getAbsolutePath() + "'", ex );
+        }
+        finally
+        {
+            if ( fileReader != null )
+            {
+                try
+                {
+                    fileReader.close();
+                }
+                catch ( IOException ex )
+                {
+                    getLogger().warn( "Failed to close file ..ignore" );
+                }
+            }
+        }
+    }
+
+    /**
+     * Validate the scm url.
+     *
+     * @param scmSpecificUrl The SCM url
+     * @param delimiter The delimiter used in the SCM url
+     * @return Returns a list of messages if the validation failed
+     */
+    @Override
+    public List<String> validateScmUrl( String scmSpecificUrl, char delimiter )
+    {
+        return super.validateScmUrl( scmSpecificUrl, delimiter );
+    }
+
+    /**
+     * Returns the scm reserved file name where the SCM stores information like 'CVS', '.svn'.
+     *
+     * @return the scm reserved file name
+     */
+    @Override
+    public String getScmSpecificFilename()
+    {
+        return REPO_DIRNAME;
+    }
+
+    /**
+     * Check if this tag is valid for this SCM provider.
+     *
+     * @param tag tag name to check
+     * @return true if tag is valid
+     */
+    @Override
+    public boolean validateTagName( String tag )
+    {
+        return gitScmProvider.validateTagName( tag );
+    }
+
+    /**
+     * Given a tag name, make it suitable for this SCM provider. For example, CVS converts "." into "_"
+     *
+     * @param tag input tag name
+     * @return sanitized tag name
+     */
+    @Override
+    public String sanitizeTagName( String tag )
+    {
+        return gitScmProvider.sanitizeTagName( tag );
+    }
+
+    /**
+     * Adds the given files to the source control system
+     *
+     * @param repository the source control system
+     * @param fileSet the files to be added
+     * @param commandParameters {@link CommandParameters}
+     * @return an {@link AddScmResult} that contains the files that have been added
+     * @throws ScmException if any
+     */
+    @Override
+    public AddScmResult add( ScmRepository repository, ScmFileSet fileSet, CommandParameters commandParameters )
+        throws ScmException
+    {
+        // TODO
+        return super.add( repository, fileSet, commandParameters );
+    }
+
+    /**
+     * Branch (or label in some systems) will create a branch of the source file with a certain branch name
+     *
+     * @param repository the source control system
+     * @param fileSet the files to branch. Implementations can also give the changes from the
+     *            {@link org.apache.maven.scm.ScmFileSet#getBasedir()} downwards.
+     * @param branchName the branch name to apply to the files
+     * @return
+     * @throws ScmException if any
+     * @since 1.3
+     */
+    @Override
+    public BranchScmResult branch( ScmRepository repository, ScmFileSet fileSet, String branchName,
+                                   ScmBranchParameters scmBranchParameters )
+        throws ScmException
+    {
+        // TODO
+        return branch( repository, fileSet, branchName, scmBranchParameters );
+    }
+
+    /**
+     * Returns the changes that have happend in the source control system in a certain period of time. This can be
+     * adding, removing, updating, ... of files
+     *
+     * @param scmRequest request wrapping detailed parameters for the changelog command
+     * @return The SCM result of the changelog command
+     * @throws ScmException if any
+     * @since 1.8
+     */
+    @Override
+    public ChangeLogScmResult changeLog( ChangeLogScmRequest scmRequest )
+        throws ScmException
+    {
+        // TODO
+        return super.changeLog( scmRequest );
+    }
+
+    /**
+     * Save the changes you have done into the repository. This will create a new version of the file or directory in
+     * the repository.
+     * <p/>
+     * When the fileSet has no entries, the fileSet.getBaseDir() is recursively committed. When the fileSet has entries,
+     * the commit is non-recursive and only the elements in the fileSet are committed.
+     *
+     * @param repository the source control system
+     * @param fileSet the files to check in (sometimes called commit)
+     * @param revision branch/tag/revision
+     * @param message a string that is a comment on the changes that where done
+     * @return
+     * @throws ScmException if any
+     */
+    @Override
+    public CheckInScmResult checkIn( ScmRepository repository, ScmFileSet fileSet, ScmVersion revision, String message )
+        throws ScmException
+    {
+        // TODO
+        return super.checkIn( repository, fileSet, revision, message );
+    }
+
+    /**
+     * Create a copy of the repository on your local machine.
+     *
+     * @param scmRepository the source control system
+     * @param scmFileSet the files are copied to the {@link org.apache.maven.scm.ScmFileSet#getBasedir()} location
+     * @param version get the version defined by the revision, branch or tag
+     * @param parameters parameters
+     * @return
+     * @throws ScmException if any
+     * @since 1.9.6
+     */
+    @Override
+    public CheckOutScmResult checkOut( ScmRepository scmRepository, ScmFileSet scmFileSet, ScmVersion scmVersion, //
+                                       CommandParameters parameters )
+        throws ScmException
+    {
+        MountReposScmProviderRepository mountRepos =
+            (MountReposScmProviderRepository) scmRepository.getProviderRepository();
+        boolean recursive = parameters.getBoolean( CommandParameter.RECURSIVE, true );
+
+        File checkoutBaseDir = scmFileSet.getBasedir();
+
+        List<ScmFile> checkedOutFiles = new ArrayList<ScmFile>();
+        for ( MountProjectRepository mountProject : mountRepos.getProjectScmProviderRepositories().values() )
+        {
+            ScmRepository mountScmRepository = mountProject.getScmRepository();
+            ScmFileSet mountScmFileSet = new ScmFileSet( new File( checkoutBaseDir, mountProject.getPath() ) );
+
+            CheckOutScmResult mountRes =
+                scmManager.checkOut( mountScmRepository, mountScmFileSet, scmVersion, recursive );
+
+            checkedOutFiles.addAll( mountRes.getCheckedOutFiles() );
+        }
+
+        copyManifestToRepoSpecificFile( mountRepos, checkoutBaseDir );
+
+        String versionName = ( scmVersion != null ) ? scmVersion.getName() : null;
+        return new CheckOutScmResult( "repo init -u " + mountRepos.getRepoManifestFile(), versionName,
+                                      checkedOutFiles );
+    }
+
+    @Override
+    protected CheckOutScmResult checkout( ScmProviderRepository scmRepository, ScmFileSet scmFileSet,
+                                          CommandParameters parameters )
+        throws ScmException
+    {
+        MountReposScmProviderRepository mountRepos = (MountReposScmProviderRepository) scmRepository;
+        ScmVersion scmVersion = parameters.getScmVersion( CommandParameter.SCM_VERSION, null );
+        boolean recursive = parameters.getBoolean( CommandParameter.RECURSIVE, true );
+        // boolean shallow = parameters.getBoolean( CommandParameter.SHALLOW, false );
+
+        File checkoutBaseDir = scmFileSet.getBasedir();
+
+        List<ScmFile> checkedOutFiles = new ArrayList<ScmFile>();
+        for ( MountProjectRepository mountProject : mountRepos.getProjectScmProviderRepositories().values() )
+        {
+            ScmRepository mountScmRepository = mountProject.getScmRepository();
+            ScmFileSet mountScmFileSet = new ScmFileSet( new File( checkoutBaseDir, mountProject.getPath() ) );
+
+            CheckOutScmResult mountRes =
+                scmManager.checkOut( mountScmRepository, mountScmFileSet, scmVersion, recursive );
+
+            checkedOutFiles.addAll( mountRes.getCheckedOutFiles() );
+        }
+
+        copyManifestToRepoSpecificFile( mountRepos, checkoutBaseDir );
+
+        String versionName = ( scmVersion != null ) ? scmVersion.getName() : null;
+        return new CheckOutScmResult( "repo update", versionName, checkedOutFiles );
+    }
+
+    /**
+     * @param mountRepos
+     * @param checkoutBaseDir
+     * @throws ScmException
+     */
+    private void copyManifestToRepoSpecificFile( MountReposScmProviderRepository mountRepos, File checkoutBaseDir )
+        throws ScmException
+    {
+        File repoScmSpecificDir = new File( checkoutBaseDir, REPO_DIRNAME );
+        if ( !repoScmSpecificDir.exists() )
+        {
+            repoScmSpecificDir.mkdirs();
+        }
+        File manifestFile = new File( checkoutBaseDir, REPO_DIRNAME + "/defaut.xml" );
+        try
+        {
+            FileUtils.copyFile( mountRepos.getRepoManifestFile(), manifestFile );
+        }
+        catch ( IOException ex )
+        {
+            throw new ScmException( "Failed to copy file " + manifestFile, ex );
+        }
+    }
+
+    /**
+     * Create a diff between two branch/tag/revision.
+     *
+     * @param scmRepository the source control system
+     * @param scmFileSet the files are copied to the {@link org.apache.maven.scm.ScmFileSet#getBasedir()} location
+     * @param startVersion the start branch/tag/revision
+     * @param endVersion the end branch/tag/revision
+     * @return
+     * @throws ScmException if any
+     */
+    @Override
+    public DiffScmResult diff( ScmRepository scmRepository, ScmFileSet scmFileSet, ScmVersion startVersion,
+                               ScmVersion endVersion )
+        throws ScmException
+    {
+        MountReposScmProviderRepository mountRepos =
+            (MountReposScmProviderRepository) scmRepository.getProviderRepository();
+        // TODO
+        return super.diff( scmRepository, scmFileSet, startVersion, endVersion );
+    }
+
+    /**
+     * Create an exported copy of the repository on your local machine
+     *
+     * @param repository the source control system
+     * @param fileSet the files are copied to the {@link org.apache.maven.scm.ScmFileSet#getBasedir()} location
+     * @param version get the version defined by the branch/tag/revision
+     * @param outputDirectory the directory where the export will be stored
+     * @return
+     * @throws ScmException if any
+     */
+    @Override
+    public ExportScmResult export( ScmRepository repository, ScmFileSet fileSet, ScmVersion version,
+                                   String outputDirectory )
+        throws ScmException
+    {
+        MountReposScmProviderRepository mountRepos =
+            (MountReposScmProviderRepository) repository.getProviderRepository();
+        // TODO
+        return super.export( repository, fileSet, version, outputDirectory );
+    }
+
+    /**
+     * Removes the given files from the source control system
+     *
+     * @param repository the source control system
+     * @param fileSet the files to be removed
+     * @param message
+     * @return
+     * @throws ScmException if any
+     */
+    @Override
+    public RemoveScmResult remove( ScmRepository repository, ScmFileSet fileSet, String message )
+        throws ScmException
+    {
+        MountReposScmProviderRepository mountRepos =
+            (MountReposScmProviderRepository) repository.getProviderRepository();
+        // TODO
+        return super.remove( repository, fileSet, message );
+    }
+
+    /**
+     * Returns the status of the files in the source control system. The state of each file can be one of the
+     * {@link org.apache.maven.scm.ScmFileStatus} flags.
+     *
+     * @param repository the source control system
+     * @param fileSet the files to know the status about. Implementations can also give the changes from the
+     *            {@link org.apache.maven.scm.ScmFileSet#getBasedir()} downwards.
+     * @return
+     * @throws ScmException if any
+     */
+    @Override
+    public StatusScmResult status( ScmRepository repository, ScmFileSet fileSet )
+        throws ScmException
+    {
+        MountReposScmProviderRepository mountRepos =
+            (MountReposScmProviderRepository) repository.getProviderRepository();
+        // TODO
+        return super.status( repository, fileSet );
+    }
+
+    /**
+     * Deletes a tag.
+     *
+     * @param repository the source control system
+     * @param fileSet a fileset with the relevant working directory as basedir
+     * @param parameters
+     * @return
+     * @throws ScmException if any
+     */
+    @Override
+    public UntagScmResult untag( ScmRepository repository, ScmFileSet fileSet, CommandParameters parameters )
+        throws ScmException
+    {
+        MountReposScmProviderRepository mountRepos =
+            (MountReposScmProviderRepository) repository.getProviderRepository();
+        // TODO
+        return super.untag( repository, fileSet, parameters );
+    }
+
+    /**
+     * Tag (or label in some systems) will tag the source file with a certain tag
+     *
+     * @param repository the source control system
+     * @param fileSet the files to tag. Implementations can also give the changes from the
+     *            {@link org.apache.maven.scm.ScmFileSet#getBasedir()} downwards.
+     * @param tagName the tag name to apply to the files
+     * @param scmTagParameters bean to pass some paramters for tagging {@link ScmTagParameters}
+     * @return
+     * @throws ScmException if any
+     * @since 1.2
+     */
+    @Override
+    public TagScmResult tag( ScmRepository repository, ScmFileSet fileSet, String tagName,
+                             ScmTagParameters scmTagParameters )
+        throws ScmException
+    {
+        MountReposScmProviderRepository mountRepos =
+            (MountReposScmProviderRepository) repository.getProviderRepository();
+        // TODO
+        return super.tag( repository, fileSet, tagName, scmTagParameters );
+    }
+
+    /**
+     * Updates the copy on the local machine with the changes in the repository
+     *
+     * @param repository the source control system
+     * @param fileSet location of your local copy
+     * @param version use the version defined by the branch/tag/revision
+     * @param lastUpdate Date of last update
+     * @param datePattern the date pattern use in changelog output returned by scm tool
+     * @return
+     * @throws ScmException if any
+     */
+    @Override
+    protected UpdateScmResult update( ScmProviderRepository repository, ScmFileSet fileSet,
+                                      CommandParameters parameters )
+        throws ScmException
+    {
+        MountReposScmProviderRepository mountRepos = (MountReposScmProviderRepository) repository;
+        File checkoutBaseDir = fileSet.getBasedir();
+
+        ScmVersion scmVersion = parameters.getScmVersion( CommandParameter.SCM_VERSION, null );
+        String datePattern = parameters.getString( CommandParameter.CHANGELOG_DATE_PATTERN, null );
+        // boolean runChangelog = parameters.getBoolean(
+        // CommandParameter.RUN_CHANGELOG_WITH_UPDATE );
+
+        List<ScmFile> updatedFiles = new ArrayList<ScmFile>();
+        for ( MountProjectRepository mountProject : mountRepos.getProjectScmProviderRepositories().values() )
+        {
+            ScmRepository mountScmRepository = mountProject.getScmRepository();
+            // ScmProviderRepository mountScmProviderRepository =
+            // mountScmRepository.getProviderRepository();
+            ScmFileSet mountScmFileSet = new ScmFileSet( new File( checkoutBaseDir, mountProject.getPath() ) );
+            ScmVersion mountScmVersion =
+                ( mountProject.revision != null ) ? new ScmBranch( mountProject.revision ) : null;
+            getLogger().info( "checkout or update project:" + mountProject.getRepoProject().getName() + " path="
+                + mountProject.getPath() + " branch=" + mountProject.revision );
+
+            try
+            {
+                UpdateScmResult mountRes =
+                    scmManager.update( mountScmRepository, mountScmFileSet, mountScmVersion, datePattern );
+
+                updatedFiles.addAll( mountRes.getUpdatedFiles() );
+            }
+            catch ( UnsupportedOperationException ex )
+            {
+                CheckOutScmResult checkOutResult =
+                    scmManager.checkOut( mountScmRepository, mountScmFileSet, mountScmVersion );
+                // ?? updatedFiles.add();
+            }
+            getLogger().info( "" );
+        }
+        return new UpdateScmResult( "repo update", updatedFiles );
+    }
+
+    /**
+     * Make a file editable. This is used in source control systems where you look at read-only files and you need to
+     * make them not read-only anymore before you can edit them. This can also mean that no other user in the system can
+     * make the file not read-only anymore.
+     *
+     * @param repository the source control system
+     * @param fileSet the files to make editable
+     * @return
+     * @throws ScmException if any
+     */
+    @Override
+    public EditScmResult edit( ScmRepository repository, ScmFileSet fileSet )
+        throws ScmException
+    {
+        MountReposScmProviderRepository mountRepos =
+            (MountReposScmProviderRepository) repository.getProviderRepository();
+        // TODO
+        return super.edit( repository, fileSet );
+    }
+
+    /**
+     * Make a file no longer editable. This is the conterpart of
+     * {@link #edit( org.apache.maven.scm.repository.ScmRepository, org.apache.maven.scm.ScmFileSet)}. It makes the file
+     * read-only again.
+     *
+     * @param repository the source control system
+     * @param fileSet the files to make uneditable
+     * @return
+     * @throws ScmException if any
+     */
+    @Override
+    public UnEditScmResult unedit( ScmRepository repository, ScmFileSet fileSet )
+        throws ScmException
+    {
+        MountReposScmProviderRepository mountRepos =
+            (MountReposScmProviderRepository) repository.getProviderRepository();
+        // TODO
+        return super.unedit( repository, fileSet );
+    }
+
+    /**
+     * List each element (files and directories) of <B>fileSet</B> as they exist in the repository.
+     *
+     * @param repository the source control system
+     * @param fileSet the files to list
+     * @param recursive descend recursively
+     * @param version use the version defined by the branch/tag/revision
+     * @return the list of files in the repository
+     * @throws ScmException if any
+     */
+    @Override
+    public ListScmResult list( ScmRepository repository, ScmFileSet fileSet, boolean recursive, ScmVersion version )
+        throws ScmException
+    {
+        MountReposScmProviderRepository mountRepos =
+            (MountReposScmProviderRepository) repository.getProviderRepository();
+        // TODO
+        return super.list( repository, fileSet, recursive, version );
+    }
+
+    /**
+     * @param blameScmRequest
+     * @return blame for the file specified in the request
+     * @throws ScmException
+     * @since 1.8
+     */
+    @Override
+    public BlameScmResult blame( BlameScmRequest blameScmRequest )
+        throws ScmException
+    {
+        MountReposScmProviderRepository mountRepos =
+            (MountReposScmProviderRepository) blameScmRequest.getScmRepository().getProviderRepository();
+        // TODO
+        return super.blame( blameScmRequest );
+    }
+
+    /**
+     * Create directory/directories in the repository.
+     *
+     * @param repository
+     * @param fileSet
+     * @param createInLocal
+     * @param message
+     * @return
+     * @throws ScmException
+     */
+    @Override
+    public MkdirScmResult mkdir( ScmRepository repository, ScmFileSet fileSet, String message, boolean createInLocal )
+        throws ScmException
+    {
+        MountReposScmProviderRepository mountRepos =
+            (MountReposScmProviderRepository) repository.getProviderRepository();
+        // TODO
+        return super.mkdir( repository, fileSet, message, createInLocal );
+    }
+
+    /**
+     * @param repository the source control system
+     * @param fileSet location of your local copy
+     * @param parameters some parameters (not use currently but for future use)
+     * @return if the scm implementation doesn't support "info" result will <code>null</code>
+     * @throws ScmException
+     * @since 1.5
+     */
+    @Override
+    public InfoScmResult info( ScmProviderRepository repository, ScmFileSet fileSet, CommandParameters parameters )
+        throws ScmException
+    {
+        MountReposScmProviderRepository mountRepos = (MountReposScmProviderRepository) repository;
+        // TODO
+        return super.info( repository, fileSet, parameters );
+    }
+
+    /**
+     * @param scmRepository the source control system
+     * @param fileSet not use currently but for future use
+     * @param parameters some parameters (not use currently but for future use)
+     * @return if the scm implementation doesn't support "info" result will <code>null</code>
+     * @throws ScmException
+     * @since 1.6
+     */
+    @Override
+    public RemoteInfoScmResult remoteInfo( ScmProviderRepository scmRepository, ScmFileSet fileSet,
+                                           CommandParameters parameters )
+        throws ScmException
+    {
+        MountReposScmProviderRepository mountRepos = (MountReposScmProviderRepository) scmRepository;
+        // TODO
+        return super.remoteInfo( scmRepository, fileSet, parameters );
+    }
+
+}

--- a/maven-scm-providers/maven-scm-provider-mountrepos/src/main/java/org/apache/maven/scm/provider/mountrepos/MountReposScmProviderRepository.java
+++ b/maven-scm-providers/maven-scm-provider-mountrepos/src/main/java/org/apache/maven/scm/provider/mountrepos/MountReposScmProviderRepository.java
@@ -1,0 +1,227 @@
+package org.apache.maven.scm.provider.mountrepos;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import java.io.File;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.apache.maven.scm.ScmFileSet;
+import org.apache.maven.scm.manager.NoSuchScmProviderException;
+import org.apache.maven.scm.manager.ScmManager;
+import org.apache.maven.scm.provider.ScmProviderRepository;
+import org.apache.maven.scm.providers.mountrepos.manifest.MountReposManifest;
+import org.apache.maven.scm.providers.mountrepos.manifest.RepoProject;
+import org.apache.maven.scm.providers.mountrepos.manifest.RepoProjectRemote;
+import org.apache.maven.scm.providers.mountrepos.manifest.RepoRemoteDefault;
+import org.apache.maven.scm.repository.ScmRepository;
+import org.apache.maven.scm.repository.ScmRepositoryException;
+import org.codehaus.plexus.util.StringUtils;
+
+/**
+ * ScmProviderRepository sub-class for "repo" tool
+ */
+public class MountReposScmProviderRepository
+    extends ScmProviderRepository
+{
+
+    private final File repoManifestFile;
+
+    private final MountReposManifest reposManifest;
+
+    public class MountProjectRepository
+    {
+
+        public final String path;
+
+        public final RepoProject repoProject;
+
+        public final ScmRepository scmRepository;
+
+        public final String revision;
+
+        public MountProjectRepository( String path, RepoProject repoProject, ScmRepository scmRepository,
+                                       String revision )
+        {
+            this.repoProject = repoProject;
+            this.scmRepository = scmRepository;
+            this.path = path;
+            this.revision = revision;
+        }
+
+        public String getPath()
+        {
+            return path;
+        }
+
+        public RepoProject getRepoProject()
+        {
+            return repoProject;
+        }
+
+        public ScmRepository getScmRepository()
+        {
+            return scmRepository;
+        }
+
+        public String getRevision()
+        {
+            return revision;
+        }
+
+    }
+
+    private Map<String, MountProjectRepository> mountProjects;
+
+    public MountReposScmProviderRepository( File repoManifestFile, MountReposManifest reposManifest,
+                                            ScmManager scmManager )
+        throws ScmRepositoryException
+    {
+        this.repoManifestFile = repoManifestFile;
+        this.reposManifest = reposManifest;
+        this.mountProjects = new LinkedHashMap<String, MountProjectRepository>();
+        RepoRemoteDefault projectDefault = reposManifest.getProjectDefault();
+        String defaultRemote = ( projectDefault != null ) ? projectDefault.getRemote() : null;
+        String defaultRevision = ( projectDefault != null ) ? projectDefault.getRevision() : null;
+        Map<String, RepoProjectRemote> remoteByName = toRemoteByName( reposManifest );
+
+        for ( RepoProject repoProject : reposManifest.getProjects() )
+        {
+            MountProjectRepository mountProject =
+                resolveProjectRepo( repoProject, scmManager, defaultRemote, defaultRevision, remoteByName );
+            mountProjects.put( repoProject.getName(), mountProject );
+        }
+    }
+
+    private MountProjectRepository resolveProjectRepo( RepoProject repoProject, ScmManager scmManager,
+                                                       String defaultRemote, String defaultRevision,
+                                                       Map<String, RepoProjectRemote> remoteByName )
+        throws ScmRepositoryException
+    {
+        String projectName = repoProject.getName();
+        String remoteName = defaultIfNull( repoProject.getRemote(), defaultRemote );
+        String revision = defaultIfNull( repoProject.getRevision(), defaultRevision );
+        RepoProjectRemote remote = remoteByName.get( remoteName );
+        if ( remote == null )
+        {
+            throw new ScmRepositoryException( "remote not found for name '" + remoteName + "', available remotes: "
+                + remoteByName.keySet() );
+        }
+        String fetch = remote.getFetch();
+        String scmUrl = "scm:jgit:" + fetch + "/" + projectName + ( ( !projectName.endsWith( ".git" ) ) ? ".git" : "" );
+        String path = defaultIfNull( repoProject.getPath(), projectName );
+
+        ScmRepository scmRepository;
+        try
+        {
+            scmRepository = scmManager.makeScmRepository( scmUrl );
+        }
+        catch ( ScmRepositoryException ex )
+        {
+            throw ex;
+        }
+        catch ( NoSuchScmProviderException e )
+        {
+            throw new ScmRepositoryException( "", e ); // should not occur
+        }
+        return new MountProjectRepository( path, repoProject, scmRepository, revision );
+    }
+
+    protected static Map<String, RepoProjectRemote> toRemoteByName( MountReposManifest reposManifest )
+    {
+        Map<String, RepoProjectRemote> res = new HashMap<String, RepoProjectRemote>();
+        for ( RepoProjectRemote remote : reposManifest.getRemotes() )
+        {
+            res.put( remote.getName(), remote );
+            String alias = remote.getAlias();
+            if ( alias != null )
+            {
+                res.put( alias, remote );
+            }
+        }
+        return res;
+    }
+
+    protected static String defaultIfNull( String value, String defaultValue )
+    {
+        return ( value != null ) ? value : defaultValue;
+    }
+
+    public File getRepoManifestFile()
+    {
+        return repoManifestFile;
+    }
+
+    public MountReposManifest getReposManifest()
+    {
+        return reposManifest;
+    }
+
+    public Map<String, MountProjectRepository> getProjectScmProviderRepositories()
+    {
+        return mountProjects;
+    }
+
+    public ScmFileSet subSetForMount( ScmFileSet fileSet, MountProjectRepository mountRepo )
+        throws IOException
+    {
+        final String path = mountRepo.path;
+        File mountBaseDir = new File( fileSet.getBasedir(), path );
+        String[] includes = StringUtils.split( fileSet.getIncludes(), "," );
+        String[] excludes = StringUtils.split( fileSet.getExcludes(), "," );
+
+        // convert && filter for base path
+        List<String> mountIncludeList = new ArrayList<>();
+        List<String> mountExcludeList = new ArrayList<>();
+        for ( String include : includes )
+        {
+            if ( include.startsWith( path ) )
+            {
+                include = include.substring( 0, path.length() );
+                mountIncludeList.add( include );
+            }
+            else if ( include.startsWith( "*" ) )
+            {
+                mountIncludeList.add( include );
+            }
+        }
+        for ( String exclude : excludes )
+        {
+            if ( exclude.startsWith( path ) )
+            {
+                exclude = exclude.substring( 0, path.length() );
+                mountExcludeList.add( exclude );
+            }
+            else if ( exclude.startsWith( "*" ) )
+            {
+                mountExcludeList.add( exclude );
+            }
+        }
+
+        String mountIncludes = StringUtils.join( mountIncludeList.iterator(), "," );
+        String mountExcludes = StringUtils.join( mountExcludeList.iterator(), "," );
+        return new ScmFileSet( mountBaseDir, mountIncludes, mountExcludes );
+    }
+
+}

--- a/maven-scm-providers/maven-scm-provider-mountrepos/src/main/mdo/manifest.dtd
+++ b/maven-scm-providers/maven-scm-provider-mountrepos/src/main/mdo/manifest.dtd
@@ -1,0 +1,83 @@
+<!DOCTYPE manifest [
+<!--
+https://gerrit.googlesource.com/git-repo/+/master/docs/manifest-format.md
+-->
+  <!ELEMENT manifest (notice?,
+                      remote*,
+                      default?,
+                      manifest-server?,
+                      remove-project*,
+                      project*,
+                      extend-project*,
+                      repo-hooks?,
+                      include*)>
+
+  <!ELEMENT notice (#PCDATA)>
+
+  <!ELEMENT remote EMPTY>
+  <!ATTLIST remote name         ID    #REQUIRED>
+  <!ATTLIST remote alias        CDATA #IMPLIED>
+  <!ATTLIST remote fetch        CDATA #REQUIRED>
+  <!ATTLIST remote pushurl      CDATA #IMPLIED>
+  <!ATTLIST remote review       CDATA #IMPLIED>
+  <!ATTLIST remote revision     CDATA #IMPLIED>
+
+  <!ELEMENT default EMPTY>
+  <!ATTLIST default remote      IDREF #IMPLIED>
+  <!ATTLIST default revision    CDATA #IMPLIED>
+  <!ATTLIST default dest-branch CDATA #IMPLIED>
+  <!ATTLIST default upstream    CDATA #IMPLIED>
+  <!ATTLIST default sync-j      CDATA #IMPLIED>
+  <!ATTLIST default sync-c      CDATA #IMPLIED>
+  <!ATTLIST default sync-s      CDATA #IMPLIED>
+  <!ATTLIST default sync-tags   CDATA #IMPLIED>
+
+  <!ELEMENT manifest-server EMPTY>
+  <!ATTLIST manifest-server url CDATA #REQUIRED>
+
+  <!ELEMENT project (annotation*,
+                     project*,
+                     copyfile*,
+                     linkfile*)>
+  <!ATTLIST project name        CDATA #REQUIRED>
+  <!ATTLIST project path        CDATA #IMPLIED>
+  <!ATTLIST project remote      IDREF #IMPLIED>
+  <!ATTLIST project revision    CDATA #IMPLIED>
+  <!ATTLIST project dest-branch CDATA #IMPLIED>
+  <!ATTLIST project groups      CDATA #IMPLIED>
+  <!ATTLIST project sync-c      CDATA #IMPLIED>
+  <!ATTLIST project sync-s      CDATA #IMPLIED>
+  <!ATTLIST project sync-tags   CDATA #IMPLIED>
+  <!ATTLIST project upstream CDATA #IMPLIED>
+  <!ATTLIST project clone-depth CDATA #IMPLIED>
+  <!ATTLIST project force-path CDATA #IMPLIED>
+
+  <!ELEMENT annotation EMPTY>
+  <!ATTLIST annotation name  CDATA #REQUIRED>
+  <!ATTLIST annotation value CDATA #REQUIRED>
+  <!ATTLIST annotation keep  CDATA "true">
+
+  <!ELEMENT copyfile EMPTY>
+  <!ATTLIST copyfile src  CDATA #REQUIRED>
+  <!ATTLIST copyfile dest CDATA #REQUIRED>
+
+  <!ELEMENT linkfile EMPTY>
+  <!ATTLIST linkfile src CDATA #REQUIRED>
+  <!ATTLIST linkfile dest CDATA #REQUIRED>
+
+  <!ELEMENT extend-project EMPTY>
+  <!ATTLIST extend-project name CDATA #REQUIRED>
+  <!ATTLIST extend-project path CDATA #IMPLIED>
+  <!ATTLIST extend-project groups CDATA #IMPLIED>
+  <!ATTLIST extend-project revision CDATA #IMPLIED>
+
+  <!ELEMENT remove-project EMPTY>
+  <!ATTLIST remove-project name  CDATA #REQUIRED>
+
+  <!ELEMENT repo-hooks EMPTY>
+  <!ATTLIST repo-hooks in-project CDATA #REQUIRED>
+  <!ATTLIST repo-hooks enabled-list CDATA #REQUIRED>
+
+  <!ELEMENT include EMPTY>
+  <!ATTLIST include name CDATA #REQUIRED>
+]>

--- a/maven-scm-providers/maven-scm-provider-mountrepos/src/main/mdo/manifest.mdo
+++ b/maven-scm-providers/maven-scm-provider-mountrepos/src/main/mdo/manifest.mdo
@@ -1,0 +1,682 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one
+  ~ or more contributor license agreements.  See the NOTICE file
+  ~ distributed with this work for additional information
+  ~ regarding copyright ownership.  The ASF licenses this file
+  ~ to you under the Apache License, Version 2.0 (the
+  ~ "License"); you may not use this file except in compliance
+  ~ with the License.  You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing,
+  ~ software distributed under the License is distributed on an
+  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  ~ KIND, either express or implied.  See the License for the
+  ~ specific language governing permissions and limitations
+  ~ under the License.
+-->
+
+<model xmlns="https://codehaus-plexus.github.io/MODELLO/1.8.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="https://codehaus-plexus.github.io/MODELLO/1.8.0 https://codehaus-plexus.github.io/modello/xsd/modello-1.8.0.xsd"
+  xml.namespace="http://maven.apache.org/SCM/mount-repos/${version}"
+  xml.schemaLocation="http://maven.apache.org/xsd/scm-mount-repos-${version}.xsd">
+  <id>manifest</id>
+  <name>MountReposManifest</name>
+  <description>Manifest for SCM Mount Repos</description>
+  <defaults>
+    <default>
+      <key>package</key>
+      <value>org.apache.maven.scm.providers.mountrepos.manifest</value>
+    </default>
+  </defaults>
+
+  <classes>
+
+<!--
+  <!ELEMENT manifest (notice?,
+                      remote*,
+                      default?,
+                      manifest-server?,
+                      remove-project*,
+                      project*,
+                      extend-project*,
+                      repo-hooks?,
+                      include*)>
+  <!ELEMENT notice (#PCDATA)>
+
+-->
+    <class rootElement="true" xml.tagName="manifest" xsd.compositor="sequence">
+      <name>MountReposManifest</name>
+      <version>1.11.3+</version>
+      <fields>
+        <field>
+          <name>notice</name>
+          <version>1.11.3+</version>
+          <type>String</type>
+          <description><![CDATA[
+          ]]></description>
+        </field>
+
+        <field xml.tagName="remote">
+          <name>remotes</name>
+          <version>1.11.3+</version>
+          <association xml.itemsStyle="flat">
+            <type>RepoProjectRemote</type>
+            <multiplicity>*</multiplicity>
+          </association>
+          <description><![CDATA[
+          ]]></description>
+        </field>
+        <field xml.tagName="default">
+          <name>projectDefault</name>
+          <version>1.11.3+</version>
+          <association>
+            <type>RepoRemoteDefault</type>
+            <multiplicity>1</multiplicity>
+          </association>
+          <description><![CDATA[
+          ]]></description>
+        </field>
+        <field xml.tagName="manifest-server">
+          <name>manifestServer</name>
+          <version>1.11.3+</version>
+          <association>
+            <type>RepoManifestServer</type>
+            <multiplicity>1</multiplicity>
+          </association>
+          <description><![CDATA[
+          ]]></description>
+        </field>
+        <field xml.tagName="project-remove">
+          <name>projectRemoves</name>
+          <version>1.11.3+</version>
+          <association xml.itemsStyle="flat">
+            <type>RepoRemoveProject</type>
+            <multiplicity>*</multiplicity>
+          </association>
+          <description><![CDATA[
+          ]]></description>
+        </field>
+        <field xml.tagName="project">
+          <name>projects</name>
+          <version>1.11.3+</version>
+          <association xml.itemsStyle="flat">
+            <type>RepoProject</type>
+            <multiplicity>*</multiplicity>
+          </association>
+          <description><![CDATA[
+          ]]></description>
+        </field>
+        <field xml.tagName="extend-project">
+          <name>extendProjects</name>
+          <version>1.11.3+</version>
+          <association xml.itemsStyle="flat">
+            <type>RepoExtendProject</type>
+            <multiplicity>*</multiplicity>
+          </association>
+          <description><![CDATA[
+          ]]></description>
+        </field>
+        <field xml.tagName="repo-hook">
+          <name>repoHooks</name>
+          <version>1.11.3+</version>
+          <association xml.itemsStyle="flat">
+            <type>RepoHook</type>
+            <multiplicity>*</multiplicity>
+          </association>
+          <description><![CDATA[
+          ]]></description>
+        </field>
+        <field xml.tagName="include">
+          <name>includes</name>
+          <version>1.11.3+</version>
+          <association xml.itemsStyle="flat">
+            <type>RepoInclude</type>
+            <multiplicity>*</multiplicity>
+          </association>
+          <description><![CDATA[
+          ]]></description>
+        </field>
+      </fields>
+    </class>
+
+
+<!--
+  <!ELEMENT remote EMPTY>
+  <!ATTLIST remote name         ID    #REQUIRED>
+  <!ATTLIST remote alias        CDATA #IMPLIED>
+  <!ATTLIST remote fetch        CDATA #REQUIRED>
+  <!ATTLIST remote pushurl      CDATA #IMPLIED>
+  <!ATTLIST remote review       CDATA #IMPLIED>
+  <!ATTLIST remote revision     CDATA #IMPLIED>
+
+One or more remote elements may be specified. Each remote element specifies a Git URL shared by one or more projects and (optionally) the Gerrit review server those projects upload changes through.
+
+-->
+    <class xml.tagName="remote">
+      <name>RepoProjectRemote</name>
+      <version>1.11.3+</version>
+      <fields>
+        <field xml.attribute="true">
+          <name>name</name>
+          <version>1.11.3+</version>
+          <type>String</type>
+          <required>true</required>
+          <description><![CDATA[A short name unique to this manifest file. The name specified here is used as the remote name in each project's .git/config, and is therefore automatically available to commands like git fetch, git remote, git pull and git push.
+          ]]></description>
+        </field>
+        <field xml.attribute="true">
+          <name>alias</name>
+          <version>1.11.3+</version>
+          <type>String</type>
+          <description><![CDATA[The alias, if specified, is used to override name to be set as the remote name in each project's .git/config. Its value can be duplicated while attribute name has to be unique in the manifest file. This helps each project to be able to have same remote name which actually points to different remote url.
+          ]]></description>
+        </field>
+        <field xml.attribute="true">
+          <name>fetch</name>
+          <version>1.11.3+</version>
+          <type>String</type>
+          <required>true</required>
+          <description><![CDATA[The Git URL prefix for all projects which use this remote. Each project's name is appended to this prefix to form the actual URL used to clone the project.
+          ]]></description>
+        </field>
+        <field xml.attribute="true">
+          <name>pushurl</name>
+          <version>1.11.3+</version>
+          <type>String</type>
+          <description><![CDATA[The Git “push” URL prefix for all projects which use this remote. Each project's name is appended to this prefix to form the actual URL used to “git push” the project. This attribute is optional; if not specified then “git push” will use the same URL as the fetch attribute.
+          ]]></description>
+        </field>
+        <field xml.attribute="true">
+          <name>review</name>
+          <version>1.11.3+</version>
+          <type>String</type>
+          <defaultValue></defaultValue>
+          <description><![CDATA[Hostname of the Gerrit server where reviews are uploaded to by repo upload. This attribute is optional; if not specified then repo upload will not function.
+          ]]></description>
+        </field>
+        <field xml.attribute="true">
+          <name>revision</name>
+          <version>1.11.3+</version>
+          <type>String</type>
+          <defaultValue></defaultValue>
+          <description><![CDATA[Name of a Git branch (e.g. master or refs/heads/master). Remotes with their own revision will override the default revision.
+          ]]></description>
+        </field>
+      </fields>
+    </class>
+
+
+<!--
+  <!ELEMENT default EMPTY>
+  <!ATTLIST default remote      IDREF #IMPLIED>
+  <!ATTLIST default revision    CDATA #IMPLIED>
+  <!ATTLIST default dest-branch CDATA #IMPLIED>
+  <!ATTLIST default upstream    CDATA #IMPLIED>
+  <!ATTLIST default sync-j      CDATA #IMPLIED>
+  <!ATTLIST default sync-c      CDATA #IMPLIED>
+  <!ATTLIST default sync-s      CDATA #IMPLIED>
+  <!ATTLIST default sync-tags   CDATA #IMPLIED>
+
+Element default
+At most one default element may be specified. Its remote and revision attributes are used when a project element does not specify its own remote or revision attribute.
+-->
+    <class xml.tagName="default">
+      <name>RepoRemoteDefault</name>
+      <version>1.11.3+</version>
+      <fields>
+        <field xml.attribute="true">
+          <name>remote</name>
+          <version>1.11.3+</version>
+          <type>String</type>
+          <description><![CDATA[
+            Name of a previously defined remote element. Project elements lacking a remote attribute of their own will use this remote.
+          ]]></description>
+        </field>
+        <field xml.attribute="true">
+          <name>revision</name>
+          <version>1.11.3+</version>
+          <type>String</type>
+          <description><![CDATA[
+            Name of a Git branch (e.g. master or refs/heads/master). Project elements lacking their own revision attribute will use this revision.
+          ]]></description>
+        </field>
+        <field xml.attribute="true" xml.attributeName="dest-branch">
+          <name>destBranch</name>
+          <version>1.11.3+</version>
+          <type>String</type>
+          <description><![CDATA[
+            Name of a Git branch (e.g. master). Project elements not setting their own dest-branch will inherit this value. If this value is not set, projects will use revision by default instead.
+          ]]></description>
+        </field>
+        <field xml.attribute="true">
+          <name>upstream</name>
+          <version>1.11.3+</version>
+          <type>String</type>
+          <description><![CDATA[
+            Name of the Git ref in which a sha1 can be found. Used when syncing a revision locked manifest in -c mode to avoid having to sync the entire ref space. Project elements not setting their own upstream will inherit this value.
+          ]]></description>
+        </field>
+        <field xml.attribute="true" xml.attributeName="sync-j">
+          <name>syncJobsCount</name>
+          <version>1.11.3+</version>
+          <type>int</type>
+          <description><![CDATA[
+            Number of parallel jobs to use when synching.
+          ]]></description>
+        </field>
+        <field xml.attribute="true" xml.attributeName="sync-c">
+          <name>syncBranchOnly</name>
+          <version>1.11.3+</version>
+          <type>boolean</type>
+          <description><![CDATA[
+            Set to true to only sync the given Git branch (specified in the revision attribute) rather than the whole ref space. Project elements lacking a sync-c element of their own will use this value.
+          ]]></description>
+        </field>
+        <field xml.attribute="true" xml.attributeName="sync-s">
+          <name>syncSubProjects</name>
+          <version>1.11.3+</version>
+          <type>boolean</type>
+          <description><![CDATA[
+            Set to true to also sync sub-projects.
+          ]]></description>
+        </field>
+        <field xml.attribute="true" xml.attributeName="sync-tags">
+          <name>syncTags</name>
+          <version>1.11.3+</version>
+          <type>boolean</type>
+          <description><![CDATA[
+            Set to false to only sync the given Git branch (specified in the revision attribute) rather than the other ref tags.
+          ]]></description>
+        </field>
+      </fields>
+    </class>
+
+<!--
+  <!ELEMENT manifest-server EMPTY>
+  <!ATTLIST manifest-server url CDATA #REQUIRED>
+-->
+    <class xml.tagName="manifest-server">
+      <name>RepoManifestServer</name>
+      <version>1.11.3+</version>
+      <fields>
+        <field>
+          <name>url</name>
+          <version>1.11.3+</version>
+          <type>String</type>
+          <required>true</required>
+          <description><![CDATA[
+          ]]></description>
+        </field>
+      </fields>
+    </class>
+
+<!--
+  <!ELEMENT project (annotation*,
+                     project*,
+                     copyfile*,
+                     linkfile*)>
+  <!ATTLIST project name        CDATA #REQUIRED>
+  <!ATTLIST project path        CDATA #IMPLIED>
+  <!ATTLIST project remote      IDREF #IMPLIED>
+  <!ATTLIST project revision    CDATA #IMPLIED>
+  <!ATTLIST project dest-branch CDATA #IMPLIED>
+  <!ATTLIST project groups      CDATA #IMPLIED>
+  <!ATTLIST project sync-c      CDATA #IMPLIED>
+  <!ATTLIST project sync-s      CDATA #IMPLIED>
+  <!ATTLIST project sync-tags   CDATA #IMPLIED>
+  <!ATTLIST project upstream CDATA #IMPLIED>
+  <!ATTLIST project clone-depth CDATA #IMPLIED>
+  <!ATTLIST project force-path CDATA #IMPLIED>
+
+One or more project elements may be specified. Each element describes a single Git repository to be cloned into the repo client workspace. You may specify Git-submodules by creating a nested project. Git-submodules will be automatically recognized and inherit their parent's attributes, but those may be overridden by an explicitly specified project element.
+-->
+    <class xml.tagName="default" xsd.compositor="sequence">
+      <name>RepoProject</name>
+      <version>1.11.3+</version>
+      <fields>
+        <field xml.tagName="annotation">
+          <name>annotations</name>
+          <version>1.11.3+</version>
+          <association xml.itemsStyle="flat">
+            <type>RepoAnnotation</type>
+            <multiplicity>*</multiplicity>
+          </association>
+          <description><![CDATA[
+          ]]></description>
+        </field>
+        <field xml.tagName="project">
+          <name>projects</name>
+          <version>1.11.3+</version>
+          <association xml.itemsStyle="flat">
+            <type>RepoProject</type>
+            <multiplicity>*</multiplicity>
+          </association>
+          <description><![CDATA[
+          ]]></description>
+        </field>
+        <field xml.tagName="copyfile">
+          <name>copyfiles</name>
+          <version>1.11.3+</version>
+          <association xml.itemsStyle="flat">
+            <type>RepoCopyFile</type>
+            <multiplicity>*</multiplicity>
+          </association>
+          <description><![CDATA[
+          ]]></description>
+        </field>
+        <field xml.tagName="linkfile">
+          <name>linkfiles</name>
+          <version>1.11.3+</version>
+          <association xml.itemsStyle="flat">
+            <type>RepoLinkFile</type>
+            <multiplicity>*</multiplicity>
+          </association>
+          <description><![CDATA[
+          ]]></description>
+        </field>
+
+        <field xml.attribute="true">
+          <name>name</name>
+          <version>1.11.3+</version>
+          <type>String</type>
+          <description><![CDATA[
+            A unique name for this project. The project‘s name is appended onto its remote’s fetch URL to generate the actual URL to configure the Git remote with. The URL gets formed as:
+${remote_fetch}/${project_name}.git
+where ${remote_fetch} is the remote‘s fetch attribute and ${project_name} is the project’s name attribute. The suffix “.git” is always appended as repo assumes the upstream is a forest of bare Git repositories. If the project has a parent element, its name will be prefixed by the parent's.
+
+The project name must match the name Gerrit knows, if Gerrit is being used for code reviews.
+          ]]></description>
+        </field>
+        <field xml.attribute="true">
+          <name>path</name>
+          <version>1.11.3+</version>
+          <type>String</type>
+          <description><![CDATA[
+An optional path relative to the top directory of the repo client where the Git working directory for this project should be placed. If not supplied the project name is used. If the project has a parent element, its path will be prefixed by the parent's.
+          ]]></description>
+        </field>
+        <field xml.attribute="true">
+          <name>remote</name>
+          <version>1.11.3+</version>
+          <type>String</type>
+          <description><![CDATA[
+Name of a previously defined remote element. If not supplied the remote given by the default element is used.
+          ]]></description>
+        </field>
+        <field xml.attribute="true">
+          <name>revision</name>
+          <version>1.11.3+</version>
+          <type>String</type>
+          <description><![CDATA[
+            Name of the Git branch the manifest wants to track for this project. Names can be relative to refs/heads (e.g. just “master”) or absolute (e.g. “refs/heads/master”). Tags and/or explicit SHA-1s should work in theory, but have not been extensively tested. If not supplied the revision given by the remote element is used if applicable, else the default element is used.
+          ]]></description>
+        </field>
+        <field xml.attribute="true" xml.attributeName="dest-branch">
+          <name>destBranch</name>
+          <version>1.11.3+</version>
+          <type>String</type>
+          <description><![CDATA[
+            Name of a Git branch (e.g. master). When using repo upload, changes will be submitted for code review on this branch. If unspecified both here and in the default element, revision is used instead.
+          ]]></description>
+        </field>
+        <field xml.attribute="true">
+          <name>groups</name>
+          <version>1.11.3+</version>
+          <type>String</type>
+          <description><![CDATA[
+            List of groups to which this project belongs, whitespace or comma separated. All projects belong to the group “all”, and each project automatically belongs to a group of its name:name and path:path. E.g. for , that project definition is implicitly in the following manifest groups: default, name:monkeys, and path:barrel-of. If you place a project in the group “notdefault”, it will not be automatically downloaded by repo. If the project has a parent element, the name and path here are the prefixed ones.
+          ]]></description>
+        </field>
+        <field xml.attribute="true" xml.attributeName="sync-c">
+          <name>syncBranchOnly</name>
+          <version>1.11.3+</version>
+          <type>String</type>
+          <description><![CDATA[
+            Set to true to only sync the given Git branch (specified in the revision attribute) rather than the whole ref space.
+          ]]></description>
+        </field>
+        <field xml.attribute="true" xml.attributeName="sync-s">
+          <name>syncSubProjects</name>
+          <version>1.11.3+</version>
+          <type>String</type>
+          <description><![CDATA[
+            Set to true to also sync sub-projects.
+          ]]></description>
+        </field>
+        <field xml.attribute="true">
+          <name>upstream</name>
+          <version>1.11.3+</version>
+          <type>String</type>
+          <description><![CDATA[
+            Name of the Git ref in which a sha1 can be found. Used when syncing a revision locked manifest in -c mode to avoid having to sync the entire ref space.
+          ]]></description>
+        </field>
+        <field xml.attribute="true" xml.attribtueName="clone-depth">
+          <name>cloneDepth</name>
+          <version>1.11.3+</version>
+          <type>int</type>
+          <description><![CDATA[
+            Set the depth to use when fetching this project. If specified, this value will override any value given to repo init with the --depth option on the command line.
+          ]]></description>
+        </field>
+        <field xml.attribute="true" xml.attribtueName="force-path">
+          <name>forcePath</name>
+          <version>1.11.3+</version>
+          <type>boolean</type>
+          <description><![CDATA[
+            Set to true to force this project to create the local mirror repository according to its path attribute (if supplied) rather than the name attribute.
+            This attribute only applies to the local mirrors syncing, it will be ignored when syncing the projects in a client working directory.
+          ]]></description>
+        </field>
+      </fields>
+    </class>
+
+<!--
+  <!ELEMENT annotation EMPTY>
+  <!ATTLIST annotation name  CDATA #REQUIRED>
+  <!ATTLIST annotation value CDATA #REQUIRED>
+  <!ATTLIST annotation keep  CDATA "true">
+-->
+    <class xml.tagName="annotation">
+      <name>RepoAnnotation</name>
+      <version>1.11.3+</version>
+      <fields>
+        <field>
+          <name>name</name>
+          <version>1.11.3+</version>
+          <type>String</type>
+          <required>true</required>
+          <description><![CDATA[
+          ]]></description>
+        </field>
+        <field>
+          <name>value</name>
+          <version>1.11.3+</version>
+          <type>String</type>
+          <required>true</required>
+          <description><![CDATA[
+          ]]></description>
+        </field>
+        <field>
+          <name>keep</name>
+          <version>1.11.3+</version>
+          <type>boolean</type>
+          <defaultValue>true</defaultValue>
+          <description><![CDATA[
+          ]]></description>
+        </field>
+      </fields>
+    </class>
+
+<!--
+  <!ELEMENT copyfile EMPTY>
+  <!ATTLIST copyfile src  CDATA #REQUIRED>
+  <!ATTLIST copyfile dest CDATA #REQUIRED>
+-->
+    <class xml.tagName="copyfile">
+      <name>RepoCopyFile</name>
+      <version>1.11.3+</version>
+      <fields>
+        <field>
+          <name>src</name>
+          <version>1.11.3+</version>
+          <type>String</type>
+          <required>true</required>
+          <description><![CDATA[
+          ]]></description>
+        </field>
+        <field>
+          <name>dest</name>
+          <version>1.11.3+</version>
+          <type>String</type>
+          <required>true</required>
+          <description><![CDATA[
+          ]]></description>
+        </field>
+      </fields>
+    </class>
+
+<!--
+  <!ELEMENT linkfile EMPTY>
+  <!ATTLIST linkfile src CDATA #REQUIRED>
+  <!ATTLIST linkfile dest CDATA #REQUIRED>
+-->
+    <class xml.tagName="linkfile">
+      <name>RepoLinkFile</name>
+      <version>1.11.3+</version>
+      <fields>
+        <field>
+          <name>src</name>
+          <version>1.11.3+</version>
+          <type>String</type>
+          <required>true</required>
+          <description><![CDATA[
+          ]]></description>
+        </field>
+        <field>
+          <name>dest</name>
+          <version>1.11.3+</version>
+          <type>String</type>
+          <required>true</required>
+          <description><![CDATA[
+          ]]></description>
+        </field>
+      </fields>
+    </class>
+
+<!--
+  <!ELEMENT extend-project EMPTY>
+  <!ATTLIST extend-project name CDATA #REQUIRED>
+  <!ATTLIST extend-project path CDATA #IMPLIED>
+  <!ATTLIST extend-project groups CDATA #IMPLIED>
+  <!ATTLIST extend-project revision CDATA #IMPLIED>
+-->
+    <class xml.tagName="extend-project">
+      <name>RepoExtendProject</name>
+      <version>1.11.3+</version>
+      <fields>
+        <field>
+          <name>name</name>
+          <version>1.11.3+</version>
+          <type>String</type>
+          <required>true</required>
+          <description><![CDATA[
+          ]]></description>
+        </field>
+        <field>
+          <name>path</name>
+          <version>1.11.3+</version>
+          <type>String</type>
+          <description><![CDATA[
+          ]]></description>
+        </field>
+        <field>
+          <name>groups</name>
+          <version>1.11.3+</version>
+          <type>String</type>
+          <description><![CDATA[
+          ]]></description>
+        </field>
+        <field>
+          <name>revision</name>
+          <version>1.11.3+</version>
+          <type>String</type>
+          <description><![CDATA[
+          ]]></description>
+        </field>
+      </fields>
+    </class>
+
+<!--
+  <!ELEMENT remove-project EMPTY>
+  <!ATTLIST remove-project name  CDATA #REQUIRED>
+-->
+    <class xml.tagName="remove-project">
+      <name>RepoRemoveProject</name>
+      <version>1.11.3+</version>
+      <fields>
+        <field>
+          <name>name</name>
+          <version>1.11.3+</version>
+          <type>String</type>
+          <required>true</required>
+          <description><![CDATA[
+          ]]></description>
+        </field>
+      </fields>
+    </class>
+
+
+<!--
+  <!ELEMENT repo-hooks EMPTY>
+  <!ATTLIST repo-hooks in-project CDATA #REQUIRED>
+  <!ATTLIST repo-hooks enabled-list CDATA #REQUIRED>
+-->
+    <class xml.tagName="repo-hooks">
+      <name>RepoHook</name>
+      <version>1.11.3+</version>
+      <fields>
+        <field xml.attributeName="in-project">
+          <name>inProject</name>
+          <version>1.11.3+</version>
+          <type>String</type>
+          <required>true</required>
+          <description><![CDATA[
+          ]]></description>
+        </field>
+        <field xml.attributeName="enabled-list">
+          <name>enabledList</name>
+          <version>1.11.3+</version>
+          <type>String</type>
+          <required>true</required>
+          <description><![CDATA[
+          ]]></description>
+        </field>
+      </fields>
+    </class>
+
+<!--
+  <!ELEMENT include EMPTY>
+  <!ATTLIST include name CDATA #REQUIRED>
+-->
+    <class xml.tagName="include">
+      <name>RepoInclude</name>
+      <version>1.11.3+</version>
+      <fields>
+        <field>
+          <name>name</name>
+          <version>1.11.3+</version>
+          <type>String</type>
+          <required>true</required>
+          <description><![CDATA[
+          ]]></description>
+        </field>
+      </fields>
+    </class>
+
+  </classes>
+</model>

--- a/maven-scm-providers/maven-scm-providers-standard/pom.xml
+++ b/maven-scm-providers/maven-scm-providers-standard/pom.xml
@@ -116,5 +116,10 @@
       <artifactId>maven-scm-provider-jazz</artifactId>
       <scope>runtime</scope>
     </dependency>
+    <dependency>
+      <groupId>org.apache.maven.scm</groupId>
+      <artifactId>maven-scm-provider-mountrepos</artifactId>
+      <scope>runtime</scope>
+    </dependency>
   </dependencies>
 </project>

--- a/maven-scm-providers/pom.xml
+++ b/maven-scm-providers/pom.xml
@@ -51,6 +51,7 @@
     <module>maven-scm-provider-tfs</module>
     <module>maven-scm-provider-integrity</module>
     <module>maven-scm-provider-jazz</module>
+    <module>maven-scm-provider-mountrepos</module>
   </modules>
 
   <dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -254,6 +254,11 @@
         <artifactId>maven-scm-provider-jazz</artifactId>
         <version>${project.version}</version>
       </dependency>
+      <dependency>
+        <groupId>org.apache.maven.scm</groupId>
+        <artifactId>maven-scm-provider-mountrepos</artifactId>
+        <version>${project.version}</version>
+      </dependency>
       <!-- end providers declaration -->
 
       <!-- Plexus -->


### PR DESCRIPTION
see jira https://issues.apache.org/jira/browse/SCM-928

as stated in https://maven.apache.org/scm.html
Checkouting maven sources can be done using google repo tool: download the file default.xml (called manifest in google repo tool), then doing "repo init"
```
repo init -u https://gitbox.apache.org/repos/asf/maven-sources.git
repo sync
repo start master --all
```

Unfortunatly, it does not work on some windows ... It requires to install python 2.7 but not 3, and mingw but not cygwin, it calls system process for ssh.exe but fails, and does not detect the correct pathes in cygwin, etc... 

This PR contains a pure java implementation of the checkout command, that is compatible with maven-scm api. It implements the parsing of the repo manifest xml file, and call jgit sub-commands  

You can test it by recompiling maven-scm, then typing either
```
mvn org.apache.maven.plugins:maven-scm-plugin:1.11.3-SNAPSHOT:checkout -DconnectionUrl=scm:mount-repos:default.xml -DcheckoutDirectory=checkout
```
or better using a new mojo that supports checkout OR update (does not clean the checkout dir if it already exists... so you can execute several times an update, or retry a partially failing checkout ) 
```
mvn org.apache.maven.plugins:maven-scm-plugin:1.11.3-SNAPSHOT:checkout-or-update -DconnectionUrl=scm:mount-repos:default.xml -DcheckoutDirectory=checkout
```

Notice that their are plenty of http 429 "Too Many Requests" will cloning some apache gitbox repositories, so this PR also contains in a separate commit a workaround  for try-catch-retry on theses errors.

Remark 1:
It is implemented s a standard "composite design-pattern" on scm repository api, eventhough the current implementation that parse manifest.xml implicitely recognise jgit sub-repositories only.
By detecting other file format, it would be possible to mix git/hg/svn.. sub repositories

Remark 2:
I named this scm type 'mount-repos' instead of 'repo' (the original name of the google repo tool) because it looks like a mount-tab file in linux: it mounts some sub-dirs to delegate to other (scm) filesystems api.

Remark 3:
For reason 1 & 2, it makes sense to be properly integrated as a maven-scm provider type. It is much more general than simply getting maven own sources code, and could be used in some complex multi-repositories builds.

Remark 4: 
Currently, only the checkout and update commands are implemented.
To fully supports maven scm api, we could also implements all remaining methods: diff/status/tag/update/edit/unedit/blame/mkdir/...


@hboutemy ... can you have a look? This work is inspired of problems discussed at hacker garten

