### PR TITLE
[SCM-931] [travis-ci] Re-establish working travis-ci for pull requests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,10 @@
 language: java
 sudo: false
 install: true
+dist: precise
 
 jdk: 
   - openjdk7
-  - openjdk6
   - oraclejdk7
   - oraclejdk8
 


### PR DESCRIPTION
While internally jenkins is used to perform testing, outside developers will not generally know that.  The project currently contains travis-ci and flipping it on shows that it fails for numerous reasons.

- Project moved to jdk7 some time back so openjdk6 is going to fail regardless
- The default travis-ci ubuntu platform is now on xenial.  Thus 'oracle' will fail due to licensing restrictions now so only openjdk is viable.
- Xenial builds use a script to get jdks and jdk 7 is no longer valid so both 'oracle' and 'open' variations will fail.
- Going back to 'trusty' will get 'oracle' for jdk 8 working but won't help with jdk7 at all.
- Going back to 'precise' will acheive getting 'openjdk7', 'oraclejdk7', and 'oraclejdk8' working.

As that is the furthest back travis-ci can go, its likely this will pop up with failures in the future once that is completely discontinued.  At that time, 'oracle' should be dropped and only openjdk8 and above should be used.  That will put more reliance on animal sniffer being accurate which feels mostly the case here.