### PR TITLE
[SCM-940] remove getModule method

### DIFF
--- a/maven-scm-providers/maven-scm-provider-local/src/test/java/org/apache/maven/scm/provider/local/repository/LocalRepositoryTest.java
+++ b/maven-scm-providers/maven-scm-provider-local/src/test/java/org/apache/maven/scm/provider/local/repository/LocalRepositoryTest.java
@@ -49,8 +49,6 @@ public class LocalRepositoryTest
 
         assertEquals( "local", repository.getProvider() );
 
-//        assertEquals( "src/test/repositories:test-repo", repository.getScmSpecificUrl() );
-
         ScmProviderRepository providerRepository = repository.getProviderRepository();
 
         assertNotNull( providerRepository );
@@ -134,10 +132,5 @@ public class LocalRepositoryTest
         {
             // expected
         }
-    }
-
-    protected String getScmUrl()
-    {
-        return "scm:local|" + getRepository() + "|" + getModule();
     }
 }

--- a/maven-scm-providers/maven-scm-providers-cvs/maven-scm-provider-cvs-commons/src/test/java/org/apache/maven/scm/provider/cvslib/command/changelog/CvsChangeLogConsumerTest.java
+++ b/maven-scm-providers/maven-scm-providers-cvs/maven-scm-provider-cvs-commons/src/test/java/org/apache/maven/scm/provider/cvslib/command/changelog/CvsChangeLogConsumerTest.java
@@ -20,6 +20,7 @@ package org.apache.maven.scm.provider.cvslib.command.changelog;
  */
 
 import org.apache.maven.scm.ChangeSet;
+import org.apache.maven.scm.ScmTestCase;
 import org.apache.maven.scm.log.DefaultLog;
 import org.apache.maven.scm.provider.cvslib.AbstractCvsScmTest;
 import org.apache.maven.scm.util.ConsumerUtils;
@@ -34,7 +35,7 @@ import java.util.Iterator;
  *
  */
 public class CvsChangeLogConsumerTest
-    extends AbstractCvsScmTest
+    extends ScmTestCase
 {
     /**
      * file with test results to check against

--- a/maven-scm-providers/maven-scm-providers-cvs/maven-scm-provider-cvs-commons/src/test/java/org/apache/maven/scm/provider/cvslib/repository/CvsScmProviderRepositoryTest.java
+++ b/maven-scm-providers/maven-scm-providers-cvs/maven-scm-provider-cvs-commons/src/test/java/org/apache/maven/scm/provider/cvslib/repository/CvsScmProviderRepositoryTest.java
@@ -1,5 +1,7 @@
 package org.apache.maven.scm.provider.cvslib.repository;
 
+import org.apache.maven.scm.ScmTestCase;
+
 /*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
@@ -20,7 +22,6 @@ package org.apache.maven.scm.provider.cvslib.repository;
  */
 
 import org.apache.maven.scm.manager.ScmManager;
-import org.apache.maven.scm.provider.cvslib.AbstractCvsScmTest;
 import org.apache.maven.scm.repository.ScmRepository;
 import org.apache.maven.scm.repository.ScmRepositoryException;
 
@@ -30,7 +31,7 @@ import org.apache.maven.scm.repository.ScmRepositoryException;
  *
  */
 public class CvsScmProviderRepositoryTest
-    extends AbstractCvsScmTest
+    extends ScmTestCase
 {
     private ScmManager scmManager;
 

--- a/maven-scm-providers/maven-scm-providers-cvs/maven-scm-provider-cvstest/src/main/java/org/apache/maven/scm/provider/cvslib/AbstractCvsScmTest.java
+++ b/maven-scm-providers/maven-scm-providers-cvs/maven-scm-provider-cvstest/src/main/java/org/apache/maven/scm/provider/cvslib/AbstractCvsScmTest.java
@@ -44,7 +44,7 @@ public abstract class AbstractCvsScmTest
     protected ScmRepository getScmRepository()
         throws Exception
     {
-        return makeScmRepository( CvsScmTestUtils.getScmUrl( getRepository(), getModule() ) );
+        return makeScmRepository( CvsScmTestUtils.getScmUrl( getRepository(), "cvs" ) );
     }
 
     public void assertBetween( long small, long large, long value )

--- a/maven-scm-providers/maven-scm-providers-cvs/maven-scm-provider-cvstest/src/main/java/org/apache/maven/scm/provider/cvslib/command/update/CvsUpdateCommandTest.java
+++ b/maven-scm-providers/maven-scm-providers-cvs/maven-scm-provider-cvstest/src/main/java/org/apache/maven/scm/provider/cvslib/command/update/CvsUpdateCommandTest.java
@@ -25,7 +25,6 @@ import org.apache.maven.scm.ScmFileStatus;
 import org.apache.maven.scm.ScmTestCase;
 import org.apache.maven.scm.command.update.UpdateScmResult;
 import org.apache.maven.scm.manager.ScmManager;
-import org.apache.maven.scm.provider.cvslib.AbstractCvsScmTest;
 import org.apache.maven.scm.provider.cvslib.CvsScmTestUtils;
 import org.apache.maven.scm.repository.ScmRepository;
 import org.codehaus.plexus.util.FileUtils;
@@ -40,7 +39,7 @@ import java.io.FileWriter;
  *
  */
 public class CvsUpdateCommandTest
-    extends AbstractCvsScmTest
+    extends ScmTestCase
 {
     private File repository;
 
@@ -65,10 +64,7 @@ public class CvsUpdateCommandTest
         CvsScmTestUtils.initRepo( repository, workingDirectory, assertionDirectory );
     }
 
-    /**
-     * {@inheritDoc}
-     */
-    protected String getModule()
+    private String getModule()
     {
         return "test-repo/update";
     }

--- a/maven-scm-test/src/main/java/org/apache/maven/scm/ScmTestCase.java
+++ b/maven-scm-test/src/main/java/org/apache/maven/scm/ScmTestCase.java
@@ -77,13 +77,6 @@ public abstract class ScmTestCase
         scmManager = null;
     }
 
-    protected String getModule()
-    {
-        fail( "getModule() must be overridden." );
-
-        return null;
-    }
-
     /**
      * @return default location of the test read/write repository
      */
@@ -170,7 +163,7 @@ public abstract class ScmTestCase
     }
 
     /**
-     * TODO This method is bogus. ActualPatch is not used and if used, it breaks
+     * TODO This method is bogus. ActualPath is not used and if used, it breaks
      * some unit tests.
      */
     public void assertPath( String expectedPath, String actualPath )
@@ -369,7 +362,7 @@ public abstract class ScmTestCase
 
     /**
      * @param cmd the executable to run, not null.
-     * @return <code>true</code>
+     * @return true iff the command is on the path
      */
     public static boolean isSystemCmd( String cmd )
     {

--- a/maven-scm-test/src/main/java/org/apache/maven/scm/ScmTestCase.java
+++ b/maven-scm-test/src/main/java/org/apache/maven/scm/ScmTestCase.java
@@ -162,10 +162,6 @@ public abstract class ScmTestCase
         return getScmManager().makeScmRepository( scmUrl );
     }
 
-    /**
-     * TODO This method is bogus. ActualPath is not used and if used, it breaks
-     * some unit tests.
-     */
     public void assertPath( String expectedPath, String actualPath )
         throws Exception
     {
@@ -362,7 +358,7 @@ public abstract class ScmTestCase
 
     /**
      * @param cmd the executable to run, not null.
-     * @return true iff the command is on the path
+     * @return true if and only if the command is on the path
      */
     public static boolean isSystemCmd( String cmd )
     {


### PR DESCRIPTION
@michael-o turns out we don't need the getModule method at all. 