### PR TITLE
[SCM-946] Added @threadSafe for parallel execution

### DIFF
--- a/maven-scm-plugin/src/main/java/org/apache/maven/scm/plugin/AbstractScmMojo.java
+++ b/maven-scm-plugin/src/main/java/org/apache/maven/scm/plugin/AbstractScmMojo.java
@@ -59,8 +59,6 @@ import org.sonatype.plexus.components.sec.dispatcher.SecDispatcherException;
  * @author Olivier Lamy
  */
  
-@Mojo( name = "ScmMojo",
-       threadSafe = false)
 public abstract class AbstractScmMojo
     extends AbstractMojo
 {

--- a/maven-scm-plugin/src/main/java/org/apache/maven/scm/plugin/AbstractScmMojo.java
+++ b/maven-scm-plugin/src/main/java/org/apache/maven/scm/plugin/AbstractScmMojo.java
@@ -31,6 +31,7 @@ import java.util.Properties;
 import org.apache.maven.plugin.AbstractMojo;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugins.annotations.Component;
+import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.Parameter;
 import org.apache.maven.scm.ScmBranch;
 import org.apache.maven.scm.ScmException;
@@ -57,6 +58,9 @@ import org.sonatype.plexus.components.sec.dispatcher.SecDispatcherException;
  * @author <a href="evenisse@apache.org">Emmanuel Venisse</a>
  * @author Olivier Lamy
  */
+ 
+@Mojo( name = "ScmMojo",
+       threadSafe = true)
 public abstract class AbstractScmMojo
     extends AbstractMojo
 {

--- a/maven-scm-plugin/src/main/java/org/apache/maven/scm/plugin/AbstractScmMojo.java
+++ b/maven-scm-plugin/src/main/java/org/apache/maven/scm/plugin/AbstractScmMojo.java
@@ -31,7 +31,6 @@ import java.util.Properties;
 import org.apache.maven.plugin.AbstractMojo;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugins.annotations.Component;
-import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.Parameter;
 import org.apache.maven.scm.ScmBranch;
 import org.apache.maven.scm.ScmException;

--- a/maven-scm-plugin/src/main/java/org/apache/maven/scm/plugin/AbstractScmMojo.java
+++ b/maven-scm-plugin/src/main/java/org/apache/maven/scm/plugin/AbstractScmMojo.java
@@ -60,7 +60,7 @@ import org.sonatype.plexus.components.sec.dispatcher.SecDispatcherException;
  */
  
 @Mojo( name = "ScmMojo",
-       threadSafe = true)
+       threadSafe = false)
 public abstract class AbstractScmMojo
     extends AbstractMojo
 {

--- a/maven-scm-plugin/src/main/java/org/apache/maven/scm/plugin/AddMojo.java
+++ b/maven-scm-plugin/src/main/java/org/apache/maven/scm/plugin/AddMojo.java
@@ -32,7 +32,7 @@ import java.io.IOException;
  *
  * @author <a href="julien.henry@capgemini.com">Julien Henry</a>
  */
-@Mojo( name = "add", aggregator = true )
+@Mojo( name = "add", aggregator = true, threadSafe = false )
 public class AddMojo
     extends AbstractScmMojo
 {

--- a/maven-scm-plugin/src/main/java/org/apache/maven/scm/plugin/BootstrapMojo.java
+++ b/maven-scm-plugin/src/main/java/org/apache/maven/scm/plugin/BootstrapMojo.java
@@ -58,7 +58,7 @@ import org.codehaus.plexus.util.cli.StreamConsumer;
  *
  * @author <a href="dantran@gmail.com">Dan T. Tran</a>
  */
-@Mojo( name = "bootstrap", requiresProject = false )
+@Mojo( name = "bootstrap", requiresProject = false, threadSafe = false )
 public class BootstrapMojo
     extends CheckoutMojo
 {

--- a/maven-scm-plugin/src/main/java/org/apache/maven/scm/plugin/BootstrapMojo.java
+++ b/maven-scm-plugin/src/main/java/org/apache/maven/scm/plugin/BootstrapMojo.java
@@ -196,7 +196,7 @@ public class BootstrapMojo
      * @param checkoutDirectory
      * @param relativePathProjectDirectory
      * @param goalsDirectory
-     * @return
+     * @return String working directory path
      */
     protected String determineWorkingDirectoryPath( File checkoutDirectory, String relativePathProjectDirectory,
                                                     String goalsDirectory )

--- a/maven-scm-plugin/src/main/java/org/apache/maven/scm/plugin/BranchMojo.java
+++ b/maven-scm-plugin/src/main/java/org/apache/maven/scm/plugin/BranchMojo.java
@@ -35,7 +35,7 @@ import java.io.IOException;
  *
  * @author <a href="evenisse@apache.org">Emmanuel Venisse</a>
  */
-@Mojo( name = "branch", aggregator = true )
+@Mojo( name = "branch", aggregator = true, threadSafe = false )
 public class BranchMojo
     extends AbstractScmMojo
 {

--- a/maven-scm-plugin/src/main/java/org/apache/maven/scm/plugin/BranchMojo.java
+++ b/maven-scm-plugin/src/main/java/org/apache/maven/scm/plugin/BranchMojo.java
@@ -66,7 +66,7 @@ public class BranchMojo
      *
      * @since 1.11.0
      *
-     * @see https://subversion.apache.org/docs/release-notes/1.9.html
+     * @see "https://subversion.apache.org/docs/release-notes/1.9.html"
      */
     @Parameter( property = "pinExternals", defaultValue = "false" )
     private boolean pinExternals;

--- a/maven-scm-plugin/src/main/java/org/apache/maven/scm/plugin/ChangeLogMojo.java
+++ b/maven-scm-plugin/src/main/java/org/apache/maven/scm/plugin/ChangeLogMojo.java
@@ -43,7 +43,7 @@ import java.util.Date;
  * @author <a href="dantran@gmail.com">Dan Tran</a>
  * @author Olivier Lamy
  */
-@Mojo( name = "changelog", aggregator = true )
+@Mojo( name = "changelog", aggregator = true, threadSafe = false )
 public class ChangeLogMojo
     extends AbstractScmMojo
 {

--- a/maven-scm-plugin/src/main/java/org/apache/maven/scm/plugin/CheckLocalModificationsMojo.java
+++ b/maven-scm-plugin/src/main/java/org/apache/maven/scm/plugin/CheckLocalModificationsMojo.java
@@ -35,7 +35,7 @@ import org.apache.maven.scm.repository.ScmRepository;
  * @author Olivier Lamy
  * @since 1.2
  */
-@Mojo( name = "check-local-modification" )
+@Mojo( name = "check-local-modification", threadSafe = false )
 public class CheckLocalModificationsMojo
     extends AbstractScmMojo
 {

--- a/maven-scm-plugin/src/main/java/org/apache/maven/scm/plugin/CheckinMojo.java
+++ b/maven-scm-plugin/src/main/java/org/apache/maven/scm/plugin/CheckinMojo.java
@@ -33,7 +33,7 @@ import java.io.IOException;
  *
  * @author <a href="evenisse@apache.org">Emmanuel Venisse</a>
  */
-@Mojo( name = "checkin", aggregator = true )
+@Mojo( name = "checkin", aggregator = true, threadSafe = false )
 public class CheckinMojo
     extends AbstractScmMojo
 {

--- a/maven-scm-plugin/src/main/java/org/apache/maven/scm/plugin/CheckoutMojo.java
+++ b/maven-scm-plugin/src/main/java/org/apache/maven/scm/plugin/CheckoutMojo.java
@@ -36,7 +36,7 @@ import org.codehaus.plexus.util.FileUtils;
  *
  * @author <a href="evenisse@apache.org">Emmanuel Venisse</a>
  */
-@Mojo( name = "checkout", requiresProject = false )
+@Mojo( name = "checkout", requiresProject = false, threadSafe = false )
 public class CheckoutMojo
     extends AbstractScmMojo
 {

--- a/maven-scm-plugin/src/main/java/org/apache/maven/scm/plugin/DiffMojo.java
+++ b/maven-scm-plugin/src/main/java/org/apache/maven/scm/plugin/DiffMojo.java
@@ -35,7 +35,7 @@ import java.io.IOException;
  *
  * @author <a href="evenisse@apache.org">Emmanuel Venisse</a>
  */
-@Mojo( name = "diff", aggregator = true )
+@Mojo( name = "diff", aggregator = true, threadSafe = false )
 public class DiffMojo
     extends AbstractScmMojo
 {

--- a/maven-scm-plugin/src/main/java/org/apache/maven/scm/plugin/EditMojo.java
+++ b/maven-scm-plugin/src/main/java/org/apache/maven/scm/plugin/EditMojo.java
@@ -32,7 +32,7 @@ import java.io.IOException;
  *
  * @author <a href="dantran@apache.org">Dan Tran</a>
  */
-@Mojo( name = "edit", aggregator = true )
+@Mojo( name = "edit", aggregator = true, threadSafe = false )
 public class EditMojo
     extends AbstractScmMojo
 {

--- a/maven-scm-plugin/src/main/java/org/apache/maven/scm/plugin/ExportMojo.java
+++ b/maven-scm-plugin/src/main/java/org/apache/maven/scm/plugin/ExportMojo.java
@@ -36,7 +36,7 @@ import org.codehaus.plexus.util.FileUtils;
  *
  * @author <a href="mailto:evenisse@apache.org">Emmanuel Venisse</a>
  */
-@Mojo( name = "export", requiresProject = false )
+@Mojo( name = "export", requiresProject = false, threadSafe = false )
 public class ExportMojo
     extends AbstractScmMojo
 {

--- a/maven-scm-plugin/src/main/java/org/apache/maven/scm/plugin/ListMojo.java
+++ b/maven-scm-plugin/src/main/java/org/apache/maven/scm/plugin/ListMojo.java
@@ -36,7 +36,7 @@ import org.apache.maven.scm.repository.ScmRepository;
  *
  * @author <a href="evenisse@apache.org">Emmanuel Venisse</a>
  */
-@Mojo( name = "list", aggregator = true )
+@Mojo( name = "list", aggregator = true, threadSafe = false )
 public class ListMojo
     extends AbstractScmMojo
 {

--- a/maven-scm-plugin/src/main/java/org/apache/maven/scm/plugin/RemoveMojo.java
+++ b/maven-scm-plugin/src/main/java/org/apache/maven/scm/plugin/RemoveMojo.java
@@ -33,7 +33,7 @@ import java.io.IOException;
  *
  * @author <a href="paul@webotech.co.uk">Paul Mackinlay</a>
  */
-@Mojo( name = "remove", aggregator = true )
+@Mojo( name = "remove", aggregator = true, threadSafe = false )
 public class RemoveMojo
     extends AbstractScmMojo
 {

--- a/maven-scm-plugin/src/main/java/org/apache/maven/scm/plugin/StatusMojo.java
+++ b/maven-scm-plugin/src/main/java/org/apache/maven/scm/plugin/StatusMojo.java
@@ -36,7 +36,7 @@ import org.codehaus.plexus.util.StringUtils;
  * @author <a href="evenisse@apache.org">Emmanuel Venisse</a>
  * @author Olivier Lamy
  */
-@Mojo( name = "status", aggregator = true )
+@Mojo( name = "status", aggregator = true, threadSafe = false )
 public class StatusMojo
     extends AbstractScmMojo
 {

--- a/maven-scm-plugin/src/main/java/org/apache/maven/scm/plugin/TagMojo.java
+++ b/maven-scm-plugin/src/main/java/org/apache/maven/scm/plugin/TagMojo.java
@@ -38,7 +38,7 @@ import java.util.Date;
  * @author <a href="evenisse@apache.org">Emmanuel Venisse</a>
  * @author <a href="saden1@gmil.com">Sharmarke Aden</a>
  */
-@Mojo( name = "tag", aggregator = true )
+@Mojo( name = "tag", aggregator = true, threadSafe = false )
 public class TagMojo
     extends AbstractScmMojo
 {

--- a/maven-scm-plugin/src/main/java/org/apache/maven/scm/plugin/UnEditMojo.java
+++ b/maven-scm-plugin/src/main/java/org/apache/maven/scm/plugin/UnEditMojo.java
@@ -32,7 +32,7 @@ import java.io.IOException;
  *
  * @author <a href="dantran@apache.org">Dan Tran</a>
  */
-@Mojo( name = "unedit", aggregator = true )
+@Mojo( name = "unedit", aggregator = true, threadSafe = false )
 public class UnEditMojo
     extends AbstractScmMojo
 {

--- a/maven-scm-plugin/src/main/java/org/apache/maven/scm/plugin/UntagMojo.java
+++ b/maven-scm-plugin/src/main/java/org/apache/maven/scm/plugin/UntagMojo.java
@@ -33,7 +33,7 @@ import org.apache.maven.scm.repository.ScmRepository;
 /**
  * Untag the project.
  */
-@Mojo( name = "untag", aggregator = true )
+@Mojo( name = "untag", aggregator = true, threadSafe = false )
 public class UntagMojo
     extends AbstractScmMojo
 {

--- a/maven-scm-plugin/src/main/java/org/apache/maven/scm/plugin/UpdateMojo.java
+++ b/maven-scm-plugin/src/main/java/org/apache/maven/scm/plugin/UpdateMojo.java
@@ -35,7 +35,7 @@ import java.io.IOException;
  *
  * @author <a href="evenisse@apache.org">Emmanuel Venisse</a>
  */
-@Mojo( name = "update", aggregator = true )
+@Mojo( name = "update", aggregator = true, threadSafe = false )
 public class UpdateMojo
     extends AbstractScmMojo
 {

--- a/maven-scm-plugin/src/main/java/org/apache/maven/scm/plugin/UpdateSubprojectsMojo.java
+++ b/maven-scm-plugin/src/main/java/org/apache/maven/scm/plugin/UpdateSubprojectsMojo.java
@@ -34,7 +34,7 @@ import java.io.IOException;
  * Updates all projects in a multi project build. This is useful for users who have adopted the flat project structure
  * where the aggregator project is a sibling of the sub projects rather than sitting in the parent directory.
  */
-@Mojo( name = "update-subprojects" )
+@Mojo( name = "update-subprojects", threadSafe = false )
 public class UpdateSubprojectsMojo
     extends AbstractScmMojo
 {

--- a/maven-scm-plugin/src/main/java/org/apache/maven/scm/plugin/ValidateMojo.java
+++ b/maven-scm-plugin/src/main/java/org/apache/maven/scm/plugin/ValidateMojo.java
@@ -36,7 +36,7 @@ import java.util.List;
  * @author <a href="evenisse@apache.org">Emmanuel Venisse</a>
  * @author Olivier Lamy
  */
-@Mojo( name = "validate", requiresProject = false )
+@Mojo( name = "validate", requiresProject = false, threadSafe = false )
 @Execute( phase = LifecyclePhase.VALIDATE )
 public class ValidateMojo
     extends AbstractScmMojo

--- a/maven-scm-plugin/src/main/java/org/apache/maven/scm/plugin/ValidateRecursively.java
+++ b/maven-scm-plugin/src/main/java/org/apache/maven/scm/plugin/ValidateRecursively.java
@@ -26,7 +26,7 @@ import org.apache.maven.plugins.annotations.Mojo;
 /**
  * Validate scm connection string recursively for all projects
  */
-@Mojo( name = "validate-recursively", requiresProject = true )
+@Mojo( name = "validate-recursively", requiresProject = true, threadSafe = false )
 @Execute( phase = LifecyclePhase.VALIDATE )
 public class ValidateRecursively
     extends ValidateMojo


### PR DESCRIPTION
**General info:**
As described in the issue [SCM-946](https://issues.apache.org/jira/projects/SCM/issues/SCM-946) there is a maven warning complaining about a missing parallel execution indicator (`@threadSafe=true/false`) for this plugin.

I don't know about the parallel execution capabilities but I added this exemplary pull request to illustrate a potential solution.
So someone with a deep knowledge of the project can decide whether to set this to true OR false but I would really appreciate if this flag would be set either way to indicate the parallel execution capabilities. 

So if the plugin (or even a mojo) it is safe for parallel execution then set `@threadSafe=true`
and if not then set `@threadSafe=false`

It should also be mentioned in the documentation like other [projects ](https://maven.apache.org/scm/maven-scm-plugin/help-mojo.html) already do it.

**Notes on the implementation:**
I added a `@threadSafe` to the parent mojo.
Alternatively for a more fine-grained control, it can also be added in the concrete classes like TagMojo:

`@Mojo( name = "tag", aggregator = true, threadSafe = true / false)`


**Update**: There are some hints (Mojo thread safety assertion checklist) on how you can check whether your plugin is thread safe:
https://cwiki.apache.org/confluence/display/MAVEN/Parallel+builds+in+Maven+3

