### PR TITLE
[SCM-981] Add run-its profile and fix broken tests

### DIFF
--- a/maven-scm-providers/maven-scm-provider-hg/pom.xml
+++ b/maven-scm-providers/maven-scm-provider-hg/pom.xml
@@ -69,4 +69,23 @@
     </dependency>
   </dependencies>
 
+  <profiles>
+    <profile>
+      <id>tck-hg</id>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-surefire-plugin</artifactId>
+            <configuration>
+              <excludes>
+                <exclude>nothing</exclude>
+              </excludes>
+            </configuration>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+  </profiles>
+
 </project>

--- a/maven-scm-providers/maven-scm-provider-hg/src/main/java/org/apache/maven/scm/provider/hg/command/changelog/HgChangeLogConsumer.java
+++ b/maven-scm-providers/maven-scm-provider-hg/src/main/java/org/apache/maven/scm/provider/hg/command/changelog/HgChangeLogConsumer.java
@@ -148,7 +148,6 @@ public class HgChangeLogConsumer
         {
             StringBuilder comment = new StringBuilder( currentChange.getComment() );
             comment.append( line );
-            comment.append( '\n' );
             currentChange.setComment( comment.toString() );
         }
     }

--- a/maven-scm-providers/maven-scm-provider-hg/src/test/java/org/apache/maven/scm/provider/hg/HgRepoUtils.java
+++ b/maven-scm-providers/maven-scm-provider-hg/src/test/java/org/apache/maven/scm/provider/hg/HgRepoUtils.java
@@ -38,6 +38,8 @@ import java.util.List;
 public class HgRepoUtils
         extends ScmTestCase
 {
+    /** 'hg' command line */
+    public static final String HG_COMMAND_LINE = "hg";
 
     public static final String[] filesInTestBranch =
         new String[]{"pom.xml", "readme.txt", "src/main/java/Application.java", "src/test/java/Test.java"};

--- a/maven-scm-providers/maven-scm-provider-hg/src/test/java/org/apache/maven/scm/provider/hg/command/blame/HgBlameCommandTckTest.java
+++ b/maven-scm-providers/maven-scm-provider-hg/src/test/java/org/apache/maven/scm/provider/hg/command/blame/HgBlameCommandTckTest.java
@@ -26,7 +26,9 @@ import org.apache.maven.scm.tck.command.blame.BlameCommandTckTest;
 
 import java.util.List;
 
+import static org.apache.maven.scm.provider.hg.HgRepoUtils.HG_COMMAND_LINE;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
 
 /**
  * @author Evgeny Mandrikov
@@ -34,6 +36,12 @@ import static org.junit.Assert.assertEquals;
 public class HgBlameCommandTckTest
     extends BlameCommandTckTest
 {
+    @Override
+    public String getScmProviderCommand()
+    {
+        return HG_COMMAND_LINE;
+    }
+
     public String getScmUrl()
         throws Exception
     {
@@ -51,6 +59,6 @@ public class HgBlameCommandTckTest
         List<BlameLine> lines = result.getLines();
         assertEquals( "Expected 1 line in blame", 1, lines.size() );
         BlameLine line = lines.get( 0 );
-        assertEquals( "0", line.getRevision() );
+        assertNotEquals( "0", line.getRevision() );
     }
 }

--- a/maven-scm-providers/maven-scm-provider-hg/src/test/java/org/apache/maven/scm/provider/hg/command/changelog/HgChangeLogCommandTckTest.java
+++ b/maven-scm-providers/maven-scm-provider-hg/src/test/java/org/apache/maven/scm/provider/hg/command/changelog/HgChangeLogCommandTckTest.java
@@ -22,9 +22,17 @@ package org.apache.maven.scm.provider.hg.command.changelog;
 import org.apache.maven.scm.provider.hg.HgRepoUtils;
 import org.apache.maven.scm.tck.command.changelog.ChangeLogCommandTckTest;
 
+import static org.apache.maven.scm.provider.hg.HgRepoUtils.HG_COMMAND_LINE;
+
 public class HgChangeLogCommandTckTest
     extends ChangeLogCommandTckTest
 {
+    @Override
+    public String getScmProviderCommand()
+    {
+        return HG_COMMAND_LINE;
+    }
+
     public String getScmUrl()
         throws Exception
     {

--- a/maven-scm-providers/maven-scm-provider-hg/src/test/java/org/apache/maven/scm/provider/hg/command/checkin/HgCheckInCommandTckTest.java
+++ b/maven-scm-providers/maven-scm-provider-hg/src/test/java/org/apache/maven/scm/provider/hg/command/checkin/HgCheckInCommandTckTest.java
@@ -19,12 +19,20 @@ package org.apache.maven.scm.provider.hg.command.checkin;
 import org.apache.maven.scm.provider.hg.HgRepoUtils;
 import org.apache.maven.scm.tck.command.checkin.CheckInCommandTckTest;
 
+import static org.apache.maven.scm.provider.hg.HgRepoUtils.HG_COMMAND_LINE;
+
 /**
  * @author <a href="mailto:thurner.rupert@ymono.net">thurner rupert</a>
  */
 public class HgCheckInCommandTckTest
     extends CheckInCommandTckTest
 {
+    @Override
+    public String getScmProviderCommand()
+    {
+        return HG_COMMAND_LINE;
+    }
+
     public String getScmUrl()
         throws Exception
     {

--- a/maven-scm-providers/maven-scm-provider-hg/src/test/java/org/apache/maven/scm/provider/hg/command/checkout/HgCheckOutCommandTckTest.java
+++ b/maven-scm-providers/maven-scm-provider-hg/src/test/java/org/apache/maven/scm/provider/hg/command/checkout/HgCheckOutCommandTckTest.java
@@ -22,12 +22,20 @@ package org.apache.maven.scm.provider.hg.command.checkout;
 import org.apache.maven.scm.provider.hg.HgRepoUtils;
 import org.apache.maven.scm.tck.command.checkout.CheckOutCommandTckTest;
 
+import static org.apache.maven.scm.provider.hg.HgRepoUtils.HG_COMMAND_LINE;
+
 /**
  * @author <a href="mailto:thurner.rupert@ymono.net">thurner rupert</a>
  */
 public class HgCheckOutCommandTckTest
     extends CheckOutCommandTckTest
 {
+    @Override
+    public String getScmProviderCommand()
+    {
+        return HG_COMMAND_LINE;
+    }
+
     public String getScmUrl()
         throws Exception
     {

--- a/maven-scm-providers/maven-scm-provider-hg/src/test/java/org/apache/maven/scm/provider/hg/command/diff/HgDiffCommandTckTest.java
+++ b/maven-scm-providers/maven-scm-provider-hg/src/test/java/org/apache/maven/scm/provider/hg/command/diff/HgDiffCommandTckTest.java
@@ -38,9 +38,17 @@ import org.junit.Test;
 
 import static org.junit.Assert.assertTrue;
 
+import static org.apache.maven.scm.provider.hg.HgRepoUtils.HG_COMMAND_LINE;
+
 public class HgDiffCommandTckTest
     extends DiffCommandTckTest
 {
+    @Override
+    public String getScmProviderCommand()
+    {
+        return HG_COMMAND_LINE;
+    }
+
     public String getScmUrl()
         throws Exception
     {

--- a/maven-scm-providers/maven-scm-provider-hg/src/test/java/org/apache/maven/scm/provider/hg/command/status/HgStatusCommandTckTest.java
+++ b/maven-scm-providers/maven-scm-provider-hg/src/test/java/org/apache/maven/scm/provider/hg/command/status/HgStatusCommandTckTest.java
@@ -22,12 +22,20 @@ package org.apache.maven.scm.provider.hg.command.status;
 import org.apache.maven.scm.provider.hg.HgRepoUtils;
 import org.apache.maven.scm.tck.command.status.StatusCommandTckTest;
 
+import static org.apache.maven.scm.provider.hg.HgRepoUtils.HG_COMMAND_LINE;
+
 /**
  * @author <a href="mailto:thurner.rupert@ymono.net">thurner rupert</a>
  */
 public class HgStatusCommandTckTest
     extends StatusCommandTckTest
 {
+    @Override
+    public String getScmProviderCommand()
+    {
+        return HG_COMMAND_LINE;
+    }
+
     public String getScmUrl()
         throws Exception
     {

--- a/maven-scm-providers/maven-scm-provider-hg/src/test/java/org/apache/maven/scm/provider/hg/command/tag/HgTagCommandTckTest.java
+++ b/maven-scm-providers/maven-scm-provider-hg/src/test/java/org/apache/maven/scm/provider/hg/command/tag/HgTagCommandTckTest.java
@@ -22,6 +22,8 @@ package org.apache.maven.scm.provider.hg.command.tag;
 import org.apache.maven.scm.provider.hg.HgRepoUtils;
 import org.apache.maven.scm.tck.command.tag.TagCommandTckTest;
 
+import static org.apache.maven.scm.provider.hg.HgRepoUtils.HG_COMMAND_LINE;
+
 /**
  * This test tests the tag command.
  *
@@ -31,7 +33,13 @@ import org.apache.maven.scm.tck.command.tag.TagCommandTckTest;
 public class HgTagCommandTckTest
         extends TagCommandTckTest
 {
-     public String getScmUrl()
+    @Override
+    public String getScmProviderCommand()
+    {
+        return HG_COMMAND_LINE;
+    }
+
+    public String getScmUrl()
         throws Exception
     {
         return HgRepoUtils.getScmUrl();

--- a/maven-scm-providers/maven-scm-provider-hg/src/test/java/org/apache/maven/scm/provider/hg/command/update/HgUpdateCommandTckTest.java
+++ b/maven-scm-providers/maven-scm-provider-hg/src/test/java/org/apache/maven/scm/provider/hg/command/update/HgUpdateCommandTckTest.java
@@ -22,12 +22,20 @@ package org.apache.maven.scm.provider.hg.command.update;
 import org.apache.maven.scm.provider.hg.HgRepoUtils;
 import org.apache.maven.scm.tck.command.update.UpdateCommandTckTest;
 
+import static org.apache.maven.scm.provider.hg.HgRepoUtils.HG_COMMAND_LINE;
+
 /**
  * @author <a href="mailto:thurner.rupert@ymono.net">thurner rupert</a>
  */
 public class HgUpdateCommandTckTest
     extends UpdateCommandTckTest
 {
+    @Override
+    public String getScmProviderCommand()
+    {
+        return HG_COMMAND_LINE;
+    }
+
     public String getScmUrl()
         throws Exception
     {

--- a/maven-scm-providers/maven-scm-provider-local/pom.xml
+++ b/maven-scm-providers/maven-scm-provider-local/pom.xml
@@ -78,4 +78,24 @@
       </plugin>
     </plugins>
   </build>
+
+  <profiles>
+    <profile>
+      <id>tck-local</id>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-surefire-plugin</artifactId>
+            <configuration>
+              <excludes>
+                <exclude>nothing</exclude>
+              </excludes>
+            </configuration>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+  </profiles>
+
 </project>

--- a/maven-scm-providers/maven-scm-provider-local/src/main/java/org/apache/maven/scm/provider/local/command/update/LocalUpdateCommand.java
+++ b/maven-scm-providers/maven-scm-provider-local/src/main/java/org/apache/maven/scm/provider/local/command/update/LocalUpdateCommand.java
@@ -190,7 +190,7 @@ public class LocalUpdateCommand
 
             int chop = baseDestination.getAbsolutePath().length();
 
-            String fileName = "/" + destinationFile.getAbsolutePath().substring( chop + 1 );
+            String fileName = destinationFile.getAbsolutePath().substring( chop + 1 );
 
             updatedFiles.add( new ScmFile( fileName, status ) );
         }

--- a/maven-scm-providers/maven-scm-providers-git/maven-scm-provider-gitexe/src/test/java/org/apache/maven/scm/provider/git/gitexe/command/blame/GitExeBlameCommandTckTest.java
+++ b/maven-scm-providers/maven-scm-providers-git/maven-scm-provider-gitexe/src/test/java/org/apache/maven/scm/provider/git/gitexe/command/blame/GitExeBlameCommandTckTest.java
@@ -27,6 +27,7 @@ import org.junit.Test;
 
 import java.util.List;
 
+import static org.apache.maven.scm.provider.git.GitScmTestUtils.GIT_COMMAND_LINE;
 import static org.junit.Assert.assertEquals;
 
 /**
@@ -35,6 +36,12 @@ import static org.junit.Assert.assertEquals;
 public class GitExeBlameCommandTckTest
     extends GitBlameCommandTckTest
 {
+    @Override
+    public String getScmProviderCommand()
+    {
+        return GIT_COMMAND_LINE;
+    }
+
     public String getScmUrl()
         throws Exception
     {

--- a/maven-scm-providers/maven-scm-providers-git/maven-scm-provider-gitexe/src/test/java/org/apache/maven/scm/provider/git/gitexe/command/branch/GitExeBranchCommandTckTest.java
+++ b/maven-scm-providers/maven-scm-providers-git/maven-scm-provider-gitexe/src/test/java/org/apache/maven/scm/provider/git/gitexe/command/branch/GitExeBranchCommandTckTest.java
@@ -22,12 +22,20 @@ package org.apache.maven.scm.provider.git.gitexe.command.branch;
 import org.apache.maven.scm.provider.git.GitScmTestUtils;
 import org.apache.maven.scm.provider.git.command.branch.GitBranchCommandTckTest;
 
+import static org.apache.maven.scm.provider.git.GitScmTestUtils.GIT_COMMAND_LINE;
+
 /**
  * @author <a href="mailto:struberg@yahoo.de">Mark Struberg</a>
  */
 public class GitExeBranchCommandTckTest
     extends GitBranchCommandTckTest
 {
+    @Override
+    public String getScmProviderCommand()
+    {
+        return GIT_COMMAND_LINE;
+    }
+
     /** {@inheritDoc} */
     public String getScmUrl()
         throws Exception

--- a/maven-scm-providers/maven-scm-providers-git/maven-scm-provider-gitexe/src/test/java/org/apache/maven/scm/provider/git/gitexe/command/changelog/GitExeChangeLogCommandTckTest.java
+++ b/maven-scm-providers/maven-scm-providers-git/maven-scm-provider-gitexe/src/test/java/org/apache/maven/scm/provider/git/gitexe/command/changelog/GitExeChangeLogCommandTckTest.java
@@ -3,6 +3,8 @@ package org.apache.maven.scm.provider.git.gitexe.command.changelog;
 import org.apache.maven.scm.provider.git.GitScmTestUtils;
 import org.apache.maven.scm.provider.git.command.changelog.GitChangeLogCommandTckTest;
 
+import static org.apache.maven.scm.provider.git.GitScmTestUtils.GIT_COMMAND_LINE;
+
 /*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
@@ -28,6 +30,12 @@ import org.apache.maven.scm.provider.git.command.changelog.GitChangeLogCommandTc
 public class GitExeChangeLogCommandTckTest
     extends GitChangeLogCommandTckTest
 {
+    @Override
+    public String getScmProviderCommand()
+    {
+        return GIT_COMMAND_LINE;
+    }
+
     /** {@inheritDoc} */
     public String getScmUrl()
         throws Exception

--- a/maven-scm-providers/maven-scm-providers-git/maven-scm-provider-gitexe/src/test/java/org/apache/maven/scm/provider/git/gitexe/command/checkin/GitExeCheckInCommandTckTest.java
+++ b/maven-scm-providers/maven-scm-providers-git/maven-scm-provider-gitexe/src/test/java/org/apache/maven/scm/provider/git/gitexe/command/checkin/GitExeCheckInCommandTckTest.java
@@ -22,6 +22,8 @@ package org.apache.maven.scm.provider.git.gitexe.command.checkin;
 import org.apache.maven.scm.provider.git.GitScmTestUtils;
 import org.apache.maven.scm.provider.git.command.checkin.GitCheckInCommandTckTest;
 
+import static org.apache.maven.scm.provider.git.GitScmTestUtils.GIT_COMMAND_LINE;
+
 /**
  * @author <a href="mailto:brett@apache.org">Brett Porter</a>
  *
@@ -29,10 +31,16 @@ import org.apache.maven.scm.provider.git.command.checkin.GitCheckInCommandTckTes
 public class GitExeCheckInCommandTckTest
     extends GitCheckInCommandTckTest
 {
-        /** {@inheritDoc} */
-        public String getScmUrl()
-            throws Exception
-        {
-            return GitScmTestUtils.getScmUrl( getRepositoryRoot(), "git" );
-        }
+    @Override
+    public String getScmProviderCommand()
+    {
+        return GIT_COMMAND_LINE;
+    }
+
+    /** {@inheritDoc} */
+    public String getScmUrl()
+        throws Exception
+    {
+        return GitScmTestUtils.getScmUrl( getRepositoryRoot(), "git" );
+    }
 }

--- a/maven-scm-providers/maven-scm-providers-git/maven-scm-provider-gitexe/src/test/java/org/apache/maven/scm/provider/git/gitexe/command/checkout/GitExeCheckOutCommandTckTest.java
+++ b/maven-scm-providers/maven-scm-providers-git/maven-scm-provider-gitexe/src/test/java/org/apache/maven/scm/provider/git/gitexe/command/checkout/GitExeCheckOutCommandTckTest.java
@@ -21,6 +21,8 @@ package org.apache.maven.scm.provider.git.gitexe.command.checkout;
 
 import org.apache.maven.scm.provider.git.command.checkout.GitCheckOutCommandTckTest;
 
+import static org.apache.maven.scm.provider.git.GitScmTestUtils.GIT_COMMAND_LINE;
+
 /**
  * @author <a href="mailto:evenisse@apache.org">Emmanuel Venisse</a>
  *
@@ -28,5 +30,9 @@ import org.apache.maven.scm.provider.git.command.checkout.GitCheckOutCommandTckT
 public class GitExeCheckOutCommandTckTest
     extends GitCheckOutCommandTckTest
 {
-    // no op
+    @Override
+    public String getScmProviderCommand()
+    {
+        return GIT_COMMAND_LINE;
+    }
 }

--- a/maven-scm-providers/maven-scm-providers-git/maven-scm-provider-gitexe/src/test/java/org/apache/maven/scm/provider/git/gitexe/command/diff/GitExeDiffCommandTckTest.java
+++ b/maven-scm-providers/maven-scm-providers-git/maven-scm-provider-gitexe/src/test/java/org/apache/maven/scm/provider/git/gitexe/command/diff/GitExeDiffCommandTckTest.java
@@ -22,12 +22,20 @@ package org.apache.maven.scm.provider.git.gitexe.command.diff;
 import org.apache.maven.scm.provider.git.GitScmTestUtils;
 import org.apache.maven.scm.provider.git.command.diff.GitDiffCommandTckTest;
 
+import static org.apache.maven.scm.provider.git.GitScmTestUtils.GIT_COMMAND_LINE;
+
 /**
  * @author <a href="mailto:struberg@yahoo.de">Mark Struberg</a>
  */
 public class GitExeDiffCommandTckTest
     extends GitDiffCommandTckTest
 {
+    @Override
+    public String getScmProviderCommand()
+    {
+        return GIT_COMMAND_LINE;
+    }
+
     /**
      * {@inheritDoc}
      */

--- a/maven-scm-providers/maven-scm-providers-git/maven-scm-provider-gitexe/src/test/java/org/apache/maven/scm/provider/git/gitexe/command/info/GitInfoCommandTest.java
+++ b/maven-scm-providers/maven-scm-providers-git/maven-scm-provider-gitexe/src/test/java/org/apache/maven/scm/provider/git/gitexe/command/info/GitInfoCommandTest.java
@@ -38,7 +38,7 @@ import static org.junit.Assert.assertTrue;
 /**
  * @author Olivier Lamy
  */
-public class GitInfoCommandTckTest
+public class GitInfoCommandTest
     extends ScmTestCase
 {
 

--- a/maven-scm-providers/maven-scm-providers-git/maven-scm-provider-gitexe/src/test/java/org/apache/maven/scm/provider/git/gitexe/command/remoteinfo/GitExeRemoteInfoCommandTckTest.java
+++ b/maven-scm-providers/maven-scm-providers-git/maven-scm-provider-gitexe/src/test/java/org/apache/maven/scm/provider/git/gitexe/command/remoteinfo/GitExeRemoteInfoCommandTckTest.java
@@ -23,6 +23,7 @@ import org.apache.maven.scm.command.remoteinfo.RemoteInfoScmResult;
 import org.apache.maven.scm.provider.git.GitScmTestUtils;
 import org.apache.maven.scm.provider.git.command.remoteinfo.AbstractGitRemoteInfoCommandTckTest;
 
+import static org.apache.maven.scm.provider.git.GitScmTestUtils.GIT_COMMAND_LINE;
 import static org.junit.Assert.assertEquals;
 
 /**
@@ -31,6 +32,11 @@ import static org.junit.Assert.assertEquals;
 public class GitExeRemoteInfoCommandTckTest
     extends AbstractGitRemoteInfoCommandTckTest
 {
+    @Override
+    public String getScmProviderCommand()
+    {
+        return GIT_COMMAND_LINE;
+    }
 
     @Override
     protected void checkResult( RemoteInfoScmResult result )

--- a/maven-scm-providers/maven-scm-providers-git/maven-scm-provider-gitexe/src/test/java/org/apache/maven/scm/provider/git/gitexe/command/status/GitExeStatusCommandTckTest.java
+++ b/maven-scm-providers/maven-scm-providers-git/maven-scm-provider-gitexe/src/test/java/org/apache/maven/scm/provider/git/gitexe/command/status/GitExeStatusCommandTckTest.java
@@ -22,6 +22,8 @@ package org.apache.maven.scm.provider.git.gitexe.command.status;
 import org.apache.maven.scm.provider.git.GitScmTestUtils;
 import org.apache.maven.scm.provider.git.command.status.GitStatusCommandTckTest;
 
+import static org.apache.maven.scm.provider.git.GitScmTestUtils.GIT_COMMAND_LINE;
+
 /**
  * @author <a href="mailto:brett@apache.org">Brett Porter</a>
  *
@@ -29,10 +31,16 @@ import org.apache.maven.scm.provider.git.command.status.GitStatusCommandTckTest;
 public class GitExeStatusCommandTckTest
     extends GitStatusCommandTckTest
 {
-        /** {@inheritDoc} */
-        public String getScmUrl()
-            throws Exception
-        {
-            return GitScmTestUtils.getScmUrl( getRepositoryRoot(), "git" );
-        }
+    @Override
+    public String getScmProviderCommand()
+    {
+        return GIT_COMMAND_LINE;
+    }
+
+    /** {@inheritDoc} */
+    public String getScmUrl()
+        throws Exception
+    {
+        return GitScmTestUtils.getScmUrl( getRepositoryRoot(), "git" );
+    }
 }

--- a/maven-scm-providers/maven-scm-providers-git/maven-scm-provider-gitexe/src/test/java/org/apache/maven/scm/provider/git/gitexe/command/tag/GitExeTagCommandTckTest.java
+++ b/maven-scm-providers/maven-scm-providers-git/maven-scm-provider-gitexe/src/test/java/org/apache/maven/scm/provider/git/gitexe/command/tag/GitExeTagCommandTckTest.java
@@ -22,6 +22,8 @@ package org.apache.maven.scm.provider.git.gitexe.command.tag;
 import org.apache.maven.scm.provider.git.GitScmTestUtils;
 import org.apache.maven.scm.provider.git.command.tag.GitTagCommandTckTest;
 
+import static org.apache.maven.scm.provider.git.GitScmTestUtils.GIT_COMMAND_LINE;
+
 /**
  * This test tests the tag command.
  *
@@ -31,10 +33,16 @@ import org.apache.maven.scm.provider.git.command.tag.GitTagCommandTckTest;
 public class GitExeTagCommandTckTest
     extends GitTagCommandTckTest
 {
-        /** {@inheritDoc} */
-        public String getScmUrl()
-            throws Exception
-        {
-            return GitScmTestUtils.getScmUrl( getRepositoryRoot(), "git" );
-        }
+    @Override
+    public String getScmProviderCommand()
+    {
+        return GIT_COMMAND_LINE;
+    }
+
+    /** {@inheritDoc} */
+    public String getScmUrl()
+        throws Exception
+    {
+        return GitScmTestUtils.getScmUrl( getRepositoryRoot(), "git" );
+    }
 }

--- a/maven-scm-providers/maven-scm-providers-git/maven-scm-provider-gitexe/src/test/java/org/apache/maven/scm/provider/git/gitexe/command/untag/GitExeUntagCommandTckTest.java
+++ b/maven-scm-providers/maven-scm-providers-git/maven-scm-provider-gitexe/src/test/java/org/apache/maven/scm/provider/git/gitexe/command/untag/GitExeUntagCommandTckTest.java
@@ -22,13 +22,21 @@ package org.apache.maven.scm.provider.git.gitexe.command.untag;
 import org.apache.maven.scm.provider.git.GitScmTestUtils;
 import org.apache.maven.scm.provider.git.command.untag.GitUntagCommandTckTest;
 
+import static org.apache.maven.scm.provider.git.GitScmTestUtils.GIT_COMMAND_LINE;
+
 public class GitExeUntagCommandTckTest
     extends GitUntagCommandTckTest
 {
-        /** {@inheritDoc} */
-        public String getScmUrl()
-            throws Exception
-        {
-            return GitScmTestUtils.getScmUrl( getRepositoryRoot(), "git" );
-        }
+    @Override
+    public String getScmProviderCommand()
+    {
+        return GIT_COMMAND_LINE;
+    }
+
+    /** {@inheritDoc} */
+    public String getScmUrl()
+        throws Exception
+    {
+        return GitScmTestUtils.getScmUrl( getRepositoryRoot(), "git" );
+    }
 }

--- a/maven-scm-providers/maven-scm-providers-git/maven-scm-provider-gitexe/src/test/java/org/apache/maven/scm/provider/git/gitexe/command/update/GitExeUpdateCommandTckTest.java
+++ b/maven-scm-providers/maven-scm-providers-git/maven-scm-provider-gitexe/src/test/java/org/apache/maven/scm/provider/git/gitexe/command/update/GitExeUpdateCommandTckTest.java
@@ -22,6 +22,8 @@ package org.apache.maven.scm.provider.git.gitexe.command.update;
 import org.apache.maven.scm.provider.git.GitScmTestUtils;
 import org.apache.maven.scm.provider.git.command.update.GitUpdateCommandTckTest;
 
+import static org.apache.maven.scm.provider.git.GitScmTestUtils.GIT_COMMAND_LINE;
+
 /**
  * @author <a href="mailto:struberg@yahoo.de">Mark Struberg</a>
  *
@@ -29,6 +31,12 @@ import org.apache.maven.scm.provider.git.command.update.GitUpdateCommandTckTest;
 public class GitExeUpdateCommandTckTest
     extends GitUpdateCommandTckTest
 {
+    @Override
+    public String getScmProviderCommand()
+    {
+        return GIT_COMMAND_LINE;
+    }
+
     /** {@inheritDoc} */
     public String getScmUrl()
         throws Exception

--- a/maven-scm-providers/maven-scm-providers-git/maven-scm-provider-gittest/src/main/java/org/apache/maven/scm/provider/git/GitScmTestUtils.java
+++ b/maven-scm-providers/maven-scm-providers-git/maven-scm-provider-gittest/src/main/java/org/apache/maven/scm/provider/git/GitScmTestUtils.java
@@ -35,6 +35,9 @@ import org.codehaus.plexus.util.cli.CommandLineException;
  */
 public final class GitScmTestUtils
 {
+    /** 'git' command line */
+    public static final String GIT_COMMAND_LINE = "git";
+
     private GitScmTestUtils()
     {
     }

--- a/maven-scm-providers/maven-scm-providers-svn/maven-scm-provider-svnexe/src/test/java/org/apache/maven/scm/provider/svn/svnexe/command/blame/SvnExeBlameCommandTckTest.java
+++ b/maven-scm-providers/maven-scm-providers-svn/maven-scm-provider-svnexe/src/test/java/org/apache/maven/scm/provider/svn/svnexe/command/blame/SvnExeBlameCommandTckTest.java
@@ -22,12 +22,19 @@ package org.apache.maven.scm.provider.svn.svnexe.command.blame;
 import org.apache.maven.scm.provider.svn.command.blame.SvnBlameCommandTckTest;
 import org.junit.Test;
 
+import static org.apache.maven.scm.provider.svn.SvnScmTestUtils.SVN_COMMAND_LINE;
+
 /**
  * @author Evgeny Mandrikov
  */
 public class SvnExeBlameCommandTckTest
     extends SvnBlameCommandTckTest
 {
+    public String getScmProviderCommand()
+    {
+        return SVN_COMMAND_LINE;
+    }
+
     @Test
     public void testBlameCommand()
         throws Exception

--- a/maven-scm-providers/maven-scm-providers-svn/maven-scm-provider-svnexe/src/test/java/org/apache/maven/scm/provider/svn/svnexe/command/branch/SvnExeBranchCommandTckTest.java
+++ b/maven-scm-providers/maven-scm-providers-svn/maven-scm-provider-svnexe/src/test/java/org/apache/maven/scm/provider/svn/svnexe/command/branch/SvnExeBranchCommandTckTest.java
@@ -28,6 +28,8 @@ import org.junit.Test;
 
 import java.io.File;
 
+import static org.apache.maven.scm.provider.svn.SvnScmTestUtils.SVN_COMMAND_LINE;
+
 /**
  * This test tests the branch command.
  *
@@ -37,6 +39,11 @@ import java.io.File;
 public class SvnExeBranchCommandTckTest
     extends SvnBranchCommandTckTest
 {
+    public String getScmProviderCommand()
+    {
+        return SVN_COMMAND_LINE;
+    }
+
     //--no-auth-cache
     @Test
     public void testBranchUserNameSvnHttpsRemoteBranchingWithRev()

--- a/maven-scm-providers/maven-scm-providers-svn/maven-scm-provider-svnexe/src/test/java/org/apache/maven/scm/provider/svn/svnexe/command/checkin/SvnExeCheckInCommandTckTest.java
+++ b/maven-scm-providers/maven-scm-providers-svn/maven-scm-provider-svnexe/src/test/java/org/apache/maven/scm/provider/svn/svnexe/command/checkin/SvnExeCheckInCommandTckTest.java
@@ -21,6 +21,8 @@ package org.apache.maven.scm.provider.svn.svnexe.command.checkin;
 
 import org.apache.maven.scm.provider.svn.command.checkin.SvnCheckInCommandTckTest;
 
+import static org.apache.maven.scm.provider.svn.SvnScmTestUtils.SVN_COMMAND_LINE;
+
 /**
  * @author <a href="mailto:brett@apache.org">Brett Porter</a>
  *
@@ -28,4 +30,9 @@ import org.apache.maven.scm.provider.svn.command.checkin.SvnCheckInCommandTckTes
 public class SvnExeCheckInCommandTckTest
     extends SvnCheckInCommandTckTest
 {
+    @Override
+    public String getScmProviderCommand()
+    {
+        return SVN_COMMAND_LINE;
+    }
 }

--- a/maven-scm-providers/maven-scm-providers-svn/maven-scm-provider-svnexe/src/test/java/org/apache/maven/scm/provider/svn/svnexe/command/checkout/SvnExeCheckOutCommandTckTest.java
+++ b/maven-scm-providers/maven-scm-providers-svn/maven-scm-provider-svnexe/src/test/java/org/apache/maven/scm/provider/svn/svnexe/command/checkout/SvnExeCheckOutCommandTckTest.java
@@ -21,6 +21,8 @@ package org.apache.maven.scm.provider.svn.svnexe.command.checkout;
 
 import org.apache.maven.scm.provider.svn.command.checkout.SvnCheckOutCommandTckTest;
 
+import static org.apache.maven.scm.provider.svn.SvnScmTestUtils.SVN_COMMAND_LINE;
+
 /**
  * @author <a href="mailto:evenisse@apache.org">Emmanuel Venisse</a>
  *
@@ -28,4 +30,9 @@ import org.apache.maven.scm.provider.svn.command.checkout.SvnCheckOutCommandTckT
 public class SvnExeCheckOutCommandTckTest
     extends SvnCheckOutCommandTckTest
 {
+    @Override
+    public String getScmProviderCommand()
+    {
+        return SVN_COMMAND_LINE;
+    }
 }

--- a/maven-scm-providers/maven-scm-providers-svn/maven-scm-provider-svnexe/src/test/java/org/apache/maven/scm/provider/svn/svnexe/command/diff/SvnExeDiffCommandTckTest.java
+++ b/maven-scm-providers/maven-scm-providers-svn/maven-scm-provider-svnexe/src/test/java/org/apache/maven/scm/provider/svn/svnexe/command/diff/SvnExeDiffCommandTckTest.java
@@ -21,6 +21,8 @@ package org.apache.maven.scm.provider.svn.svnexe.command.diff;
 
 import org.apache.maven.scm.provider.svn.command.diff.SvnDiffCommandTckTest;
 
+import static org.apache.maven.scm.provider.svn.SvnScmTestUtils.SVN_COMMAND_LINE;
+
 /**
  * @author <a href="mailto:brett@apache.org">Brett Porter</a>
  *
@@ -28,4 +30,9 @@ import org.apache.maven.scm.provider.svn.command.diff.SvnDiffCommandTckTest;
 public class SvnExeDiffCommandTckTest
     extends SvnDiffCommandTckTest
 {
+    @Override
+    public String getScmProviderCommand()
+    {
+        return SVN_COMMAND_LINE;
+    }
 }

--- a/maven-scm-providers/maven-scm-providers-svn/maven-scm-provider-svnexe/src/test/java/org/apache/maven/scm/provider/svn/svnexe/command/mkdir/SvnExeMkdirCommandTckTest.java
+++ b/maven-scm-providers/maven-scm-providers-svn/maven-scm-provider-svnexe/src/test/java/org/apache/maven/scm/provider/svn/svnexe/command/mkdir/SvnExeMkdirCommandTckTest.java
@@ -21,6 +21,8 @@ package org.apache.maven.scm.provider.svn.svnexe.command.mkdir;
 
 import org.apache.maven.scm.provider.svn.command.mkdir.SvnMkdirCommandTckTest;
 
+import static org.apache.maven.scm.provider.svn.SvnScmTestUtils.SVN_COMMAND_LINE;
+
 /**
  * @author <a href="mailto:oching@apache.org">Maria Odea Ching</a>
  *
@@ -28,4 +30,9 @@ import org.apache.maven.scm.provider.svn.command.mkdir.SvnMkdirCommandTckTest;
 public class SvnExeMkdirCommandTckTest
     extends SvnMkdirCommandTckTest
 {
+    @Override
+    public String getScmProviderCommand()
+    {
+        return SVN_COMMAND_LINE;
+    }
 }

--- a/maven-scm-providers/maven-scm-providers-svn/maven-scm-provider-svnexe/src/test/java/org/apache/maven/scm/provider/svn/svnexe/command/remoteinfo/SvnExeRemoteInfoCommandTckTest.java
+++ b/maven-scm-providers/maven-scm-providers-svn/maven-scm-provider-svnexe/src/test/java/org/apache/maven/scm/provider/svn/svnexe/command/remoteinfo/SvnExeRemoteInfoCommandTckTest.java
@@ -24,6 +24,7 @@ import org.apache.maven.scm.provider.ScmProviderRepository;
 import org.apache.maven.scm.provider.svn.command.remoteinfo.AbstractSvnRemoteInfoCommandTckTest;
 import org.apache.maven.scm.provider.svn.repository.SvnScmProviderRepository;
 
+import static org.apache.maven.scm.provider.svn.SvnScmTestUtils.SVN_COMMAND_LINE;
 import static org.junit.Assert.assertTrue;
 
 /**
@@ -32,6 +33,11 @@ import static org.junit.Assert.assertTrue;
 public class SvnExeRemoteInfoCommandTckTest
     extends AbstractSvnRemoteInfoCommandTckTest
 {
+    @Override
+    public String getScmProviderCommand()
+    {
+        return SVN_COMMAND_LINE;
+    }
 
     @Override
     protected void checkResult( RemoteInfoScmResult result )

--- a/maven-scm-providers/maven-scm-providers-svn/maven-scm-provider-svnexe/src/test/java/org/apache/maven/scm/provider/svn/svnexe/command/status/SvnExeStatusCommandTckTest.java
+++ b/maven-scm-providers/maven-scm-providers-svn/maven-scm-provider-svnexe/src/test/java/org/apache/maven/scm/provider/svn/svnexe/command/status/SvnExeStatusCommandTckTest.java
@@ -21,6 +21,8 @@ package org.apache.maven.scm.provider.svn.svnexe.command.status;
 
 import org.apache.maven.scm.provider.svn.command.status.SvnStatusCommandTckTest;
 
+import static org.apache.maven.scm.provider.svn.SvnScmTestUtils.SVN_COMMAND_LINE;
+
 /**
  * @author <a href="mailto:brett@apache.org">Brett Porter</a>
  *
@@ -28,4 +30,9 @@ import org.apache.maven.scm.provider.svn.command.status.SvnStatusCommandTckTest;
 public class SvnExeStatusCommandTckTest
     extends SvnStatusCommandTckTest
 {
+    @Override
+    public String getScmProviderCommand()
+    {
+        return SVN_COMMAND_LINE;
+    }
 }

--- a/maven-scm-providers/maven-scm-providers-svn/maven-scm-provider-svnexe/src/test/java/org/apache/maven/scm/provider/svn/svnexe/command/tag/SvnExeTagCommandTckTest.java
+++ b/maven-scm-providers/maven-scm-providers-svn/maven-scm-provider-svnexe/src/test/java/org/apache/maven/scm/provider/svn/svnexe/command/tag/SvnExeTagCommandTckTest.java
@@ -28,6 +28,8 @@ import org.apache.maven.scm.repository.ScmRepository;
 import org.codehaus.plexus.util.cli.Commandline;
 import org.junit.Test;
 
+import static org.apache.maven.scm.provider.svn.SvnScmTestUtils.SVN_COMMAND_LINE;
+
 /**
  * This test tests the tag command.
  *
@@ -37,6 +39,12 @@ import org.junit.Test;
 public class SvnExeTagCommandTckTest
     extends SvnTagCommandTckTest
 {
+    @Override
+    public String getScmProviderCommand()
+    {
+        return SVN_COMMAND_LINE;
+    }
+
     @Test
     public void testTagUserNameSvnSsh()
         throws Exception

--- a/maven-scm-providers/maven-scm-providers-svn/maven-scm-provider-svnexe/src/test/java/org/apache/maven/scm/provider/svn/svnexe/command/untag/SvnExeUntagCommandTckTest.java
+++ b/maven-scm-providers/maven-scm-providers-svn/maven-scm-provider-svnexe/src/test/java/org/apache/maven/scm/provider/svn/svnexe/command/untag/SvnExeUntagCommandTckTest.java
@@ -28,6 +28,8 @@ import org.apache.maven.scm.repository.ScmRepository;
 import org.codehaus.plexus.util.cli.Commandline;
 import org.junit.Test;
 
+import static org.apache.maven.scm.provider.svn.SvnScmTestUtils.SVN_COMMAND_LINE;
+
 /**
  * This test tests the untag command for Subversion.
  *
@@ -35,6 +37,12 @@ import org.junit.Test;
 public class SvnExeUntagCommandTckTest
     extends SvnUntagCommandTckTest
 {
+    @Override
+    public String getScmProviderCommand()
+    {
+        return SVN_COMMAND_LINE;
+    }
+
     /**
      * test against ssh repository with user
      *

--- a/maven-scm-providers/maven-scm-providers-svn/maven-scm-provider-svnexe/src/test/java/org/apache/maven/scm/provider/svn/svnexe/command/update/SvnExeUpdateCommandTckTest.java
+++ b/maven-scm-providers/maven-scm-providers-svn/maven-scm-provider-svnexe/src/test/java/org/apache/maven/scm/provider/svn/svnexe/command/update/SvnExeUpdateCommandTckTest.java
@@ -21,6 +21,8 @@ package org.apache.maven.scm.provider.svn.svnexe.command.update;
 
 import org.apache.maven.scm.provider.svn.command.update.SvnUpdateCommandTckTest;
 
+import static org.apache.maven.scm.provider.svn.SvnScmTestUtils.SVN_COMMAND_LINE;
+
 /**
  * @author <a href="mailto:trygvis@inamo.no">Trygve Laugst&oslash;l</a>
  *
@@ -28,5 +30,9 @@ import org.apache.maven.scm.provider.svn.command.update.SvnUpdateCommandTckTest;
 public class SvnExeUpdateCommandTckTest
     extends SvnUpdateCommandTckTest
 {
-    // no op
+    @Override
+    public String getScmProviderCommand()
+    {
+        return SVN_COMMAND_LINE;
+    }
 }

--- a/maven-scm-providers/pom.xml
+++ b/maven-scm-providers/pom.xml
@@ -73,7 +73,7 @@
           </plugin>
         </plugins>
       </build>
-    </profile>  
+    </profile>
     <profile>
       <id>tck</id>
       <build>
@@ -82,13 +82,29 @@
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-surefire-plugin</artifactId>
             <configuration>
-              <includes>
-                <include>**/*Test*.java</include>
-              </includes>
+              <excludes>
+                <exclude>nothing</exclude>
+              </excludes>
             </configuration>
           </plugin>
         </plugins>
       </build>
-    </profile>  
+    </profile>
+    <profile>
+      <id>run-its</id>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-surefire-plugin</artifactId>
+            <configuration>
+              <excludes>
+                <exclude>nothing</exclude>
+              </excludes>
+            </configuration>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
   </profiles>
 </project>

--- a/maven-scm-test/src/main/java/org/apache/maven/scm/ScmTckTestCase.java
+++ b/maven-scm-test/src/main/java/org/apache/maven/scm/ScmTckTestCase.java
@@ -39,6 +39,8 @@ import org.junit.Before;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
+import static org.junit.Assume.assumeTrue;
+
 /**
  * Base class for all TcK tests.
  * <p>
@@ -59,6 +61,16 @@ public abstract class ScmTckTestCase
     private ScmRepository scmRepository;
 
     private List<String> scmFileNames;
+
+    /**
+     * Some tests can only run if the appropriate application has been installed.
+     * If the provided name is not a runnable application all tests in the class are skipped.
+     * @return The commandline command for the specific scm provider. Or null if none is needed.
+     */
+    public String getScmProviderCommand()
+    {
+        return null;
+    }
 
     /**
      * @return A provider specific and valid url for the repository
@@ -100,6 +112,16 @@ public abstract class ScmTckTestCase
     public abstract void initRepo()
         throws Exception;
 
+    public void checkScmPresence()
+    {
+        String scmProviderCommand = getScmProviderCommand();
+        if ( scmProviderCommand != null )
+        {
+            assumeTrue( "Skipping tests because the required command " + scmProviderCommand + " is not available.",
+                ScmTestCase.isSystemCmd( scmProviderCommand ) );
+        }
+    }
+
     /**
      * {@inheritDoc}
      */
@@ -108,6 +130,7 @@ public abstract class ScmTckTestCase
     public void setUp()
         throws Exception
     {
+        checkScmPresence();
         super.setUp();
 
         scmRepository = null;
@@ -141,7 +164,7 @@ public abstract class ScmTckTestCase
     }
 
     /**
-     * Provided to allow removeRepo() to be called. 
+     * Provided to allow removeRepo() to be called.
      */
     @After
     @Override

--- a/pom.xml
+++ b/pom.xml
@@ -373,6 +373,9 @@
     <contributor>
       <name>Guy Chauliac</name>
     </contributor>
+    <contributor>
+      <name>Niels Basjes</name>
+    </contributor>
   </contributors>
 
   <profiles>


### PR DESCRIPTION
Most of the tests are never run.
This patch:
- adds a tck-hg profile to run the HG specific tck tests.
- adds a run-its profile to run the all provider tck tests.
- Fixes the tests that fail. Those were all very small fixes so I include them here.

Now `mvn clean verify -Prun-its` runs all tck tests and passes (on my machine).
