### PR TITLE
[SCM-925] Implement RemoveCommand in maven-scm-provider-jgit

### DIFF
--- a/maven-scm-providers/maven-scm-providers-git/maven-scm-provider-gittest/src/main/java/org/apache/maven/scm/provider/git/command/remove/GitRemoveCommandTckTest.java
+++ b/maven-scm-providers/maven-scm-providers-git/maven-scm-provider-gittest/src/main/java/org/apache/maven/scm/provider/git/command/remove/GitRemoveCommandTckTest.java
@@ -20,7 +20,6 @@ package org.apache.maven.scm.provider.git.command.remove;
  */
 
 import java.io.File;
-import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.StandardOpenOption;
@@ -30,7 +29,6 @@ import org.apache.maven.scm.ScmFileSet;
 import org.apache.maven.scm.ScmTckTestCase;
 import org.apache.maven.scm.command.remove.RemoveScmResult;
 import org.apache.maven.scm.provider.git.GitScmTestUtils;
-import org.codehaus.plexus.util.FileUtils;
 
 /**
  * This test tests the remove command.
@@ -50,9 +48,7 @@ public abstract class GitRemoveCommandTckTest
     public void testCommandRemoveWithFile()
         throws Exception
     {
-        File workingDirectory = createTempDirectory();
-
-        File toBeRemoved = new File( workingDirectory.getAbsolutePath() + File.separator + "toto.xml" );
+        File toBeRemoved = new File( getWorkingDirectory().getAbsolutePath() + File.separator + "toto.xml" );
 
         Files.write( toBeRemoved.getAbsoluteFile().toPath(),
             "data".getBytes( StandardCharsets.UTF_8 ), StandardOpenOption.APPEND, StandardOpenOption.CREATE );
@@ -60,48 +56,30 @@ public abstract class GitRemoveCommandTckTest
         ScmFileSet fileSet =  new ScmFileSet( getWorkingCopy(), toBeRemoved );
         RemoveScmResult removeResult = getScmManager().remove( getScmRepository(), fileSet, getBasedir() );
         assertResultIsSuccess( removeResult );
-
-        FileUtils.deleteDirectory( workingDirectory );
     }
 
     public void testCommandRemoveWithDirectory()
         throws Exception
     {
-        File workingDirectory = createTempDirectory();
-
-        File toBeRemoved = new File( workingDirectory.getAbsolutePath() + File.separator + "toto" );
+        File toBeRemoved = new File( getWorkingDirectory().getAbsolutePath() + File.separator + "toto" );
         toBeRemoved.mkdir();
 
         ScmFileSet fileSet =  new ScmFileSet( getWorkingCopy(), toBeRemoved );
         RemoveScmResult removeResult = getScmManager().remove( getScmRepository(), fileSet, getBasedir() );
         assertResultIsSuccess( removeResult );
-
-        FileUtils.deleteDirectory( workingDirectory );
     }
 
     public void testCommandRemoveWithTwoDirectories()
         throws Exception
     {
-        File workingDirectory = createTempDirectory();
-
-        File toBeRemoved1 = new File( workingDirectory.getAbsolutePath() + File.separator + "toto" );
+        File toBeRemoved1 = new File( getWorkingDirectory().getAbsolutePath() + File.separator + "toto" );
         toBeRemoved1.mkdir();
 
-        File toBeRemoved2 = new File( workingDirectory.getAbsolutePath() + File.separator + "tata" );
+        File toBeRemoved2 = new File( getWorkingDirectory().getAbsolutePath() + File.separator + "tata" );
         toBeRemoved2.mkdir();
 
         ScmFileSet fileSet =  new ScmFileSet( getWorkingCopy(), Arrays.asList( toBeRemoved1, toBeRemoved2 ) );
         RemoveScmResult removeResult = getScmManager().remove( getScmRepository(), fileSet, getBasedir() );
         assertResultIsSuccess( removeResult );
-        FileUtils.deleteDirectory( workingDirectory );
-    }
-
-    private File createTempDirectory()
-        throws IOException
-    {
-        File dir = File.createTempFile( "gitexe", "test" );
-        dir.delete();
-        dir.mkdir();
-        return dir;
     }
 }

--- a/maven-scm-providers/maven-scm-providers-git/maven-scm-provider-gittest/src/main/java/org/apache/maven/scm/provider/git/command/remove/GitRemoveCommandTckTest.java
+++ b/maven-scm-providers/maven-scm-providers-git/maven-scm-provider-gittest/src/main/java/org/apache/maven/scm/provider/git/command/remove/GitRemoveCommandTckTest.java
@@ -1,0 +1,107 @@
+package org.apache.maven.scm.provider.git.command.remove;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.StandardOpenOption;
+import java.util.Arrays;
+
+import org.apache.maven.scm.ScmFileSet;
+import org.apache.maven.scm.ScmTckTestCase;
+import org.apache.maven.scm.command.remove.RemoveScmResult;
+import org.apache.maven.scm.provider.git.GitScmTestUtils;
+import org.codehaus.plexus.util.FileUtils;
+
+/**
+ * This test tests the remove command.
+ *
+ * @author Georg Tsakumagos
+ */
+public abstract class GitRemoveCommandTckTest
+    extends ScmTckTestCase
+{
+    /** {@inheritDoc} */
+    public void initRepo()
+        throws Exception
+    {
+        GitScmTestUtils.initRepo( "src/test/resources/repository/", getRepositoryRoot(), getWorkingDirectory() );
+    }
+
+    public void testCommandRemoveWithFile()
+        throws Exception
+    {
+        File workingDirectory = createTempDirectory();
+
+        File toBeRemoved = new File( workingDirectory.getAbsolutePath() + File.separator + "toto.xml" );
+
+        Files.write( toBeRemoved.getAbsoluteFile().toPath(),
+            "data".getBytes( StandardCharsets.UTF_8 ), StandardOpenOption.APPEND, StandardOpenOption.CREATE );
+
+        ScmFileSet fileSet =  new ScmFileSet( getWorkingCopy(), toBeRemoved );
+        RemoveScmResult removeResult = getScmManager().remove( getScmRepository(), fileSet, getBasedir() );
+        assertResultIsSuccess( removeResult );
+
+        FileUtils.deleteDirectory( workingDirectory );
+    }
+
+    public void testCommandRemoveWithDirectory()
+        throws Exception
+    {
+        File workingDirectory = createTempDirectory();
+
+        File toBeRemoved = new File( workingDirectory.getAbsolutePath() + File.separator + "toto" );
+        toBeRemoved.mkdir();
+
+        ScmFileSet fileSet =  new ScmFileSet( getWorkingCopy(), toBeRemoved );
+        RemoveScmResult removeResult = getScmManager().remove( getScmRepository(), fileSet, getBasedir() );
+        assertResultIsSuccess( removeResult );
+
+        FileUtils.deleteDirectory( workingDirectory );
+    }
+
+    public void testCommandRemoveWithTwoDirectories()
+        throws Exception
+    {
+        File workingDirectory = createTempDirectory();
+
+        File toBeRemoved1 = new File( workingDirectory.getAbsolutePath() + File.separator + "toto" );
+        toBeRemoved1.mkdir();
+
+        File toBeRemoved2 = new File( workingDirectory.getAbsolutePath() + File.separator + "tata" );
+        toBeRemoved2.mkdir();
+
+        ScmFileSet fileSet =  new ScmFileSet( getWorkingCopy(), Arrays.asList( toBeRemoved1, toBeRemoved2 ) );
+        RemoveScmResult removeResult = getScmManager().remove( getScmRepository(), fileSet, getBasedir() );
+        assertResultIsSuccess( removeResult );
+        FileUtils.deleteDirectory( workingDirectory );
+    }
+
+    private File createTempDirectory()
+        throws IOException
+    {
+        File dir = File.createTempFile( "gitexe", "test" );
+        dir.delete();
+        dir.mkdir();
+        return dir;
+    }
+}

--- a/maven-scm-providers/maven-scm-providers-git/maven-scm-provider-gittest/src/main/java/org/apache/maven/scm/provider/git/command/remove/GitRemoveCommandTckTest.java
+++ b/maven-scm-providers/maven-scm-providers-git/maven-scm-provider-gittest/src/main/java/org/apache/maven/scm/provider/git/command/remove/GitRemoveCommandTckTest.java
@@ -24,11 +24,13 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.StandardOpenOption;
 import java.util.Arrays;
+import java.util.Collections;
 
 import org.apache.maven.scm.ScmFileSet;
 import org.apache.maven.scm.ScmTckTestCase;
 import org.apache.maven.scm.command.remove.RemoveScmResult;
 import org.apache.maven.scm.provider.git.GitScmTestUtils;
+import org.junit.Test;
 
 /**
  * This test tests the remove command.
@@ -45,23 +47,25 @@ public abstract class GitRemoveCommandTckTest
         GitScmTestUtils.initRepo( "src/test/resources/repository/", getRepositoryRoot(), getWorkingDirectory() );
     }
 
+    @Test
     public void testCommandRemoveWithFile()
         throws Exception
     {
-        File toBeRemoved = new File( getWorkingDirectory().getAbsolutePath() + File.separator + "toto.xml" );
+        File toBeRemoved = new File( getWorkingDirectory(), "toto.xml" );
 
-        Files.write( toBeRemoved.getAbsoluteFile().toPath(),
-            "data".getBytes( StandardCharsets.UTF_8 ), StandardOpenOption.APPEND, StandardOpenOption.CREATE );
+        Files.write( toBeRemoved.toPath(), Collections.singletonList( "data" ),
+            StandardCharsets.US_ASCII, StandardOpenOption.CREATE );
 
         ScmFileSet fileSet =  new ScmFileSet( getWorkingCopy(), toBeRemoved );
         RemoveScmResult removeResult = getScmManager().remove( getScmRepository(), fileSet, getBasedir() );
         assertResultIsSuccess( removeResult );
     }
 
+    @Test
     public void testCommandRemoveWithDirectory()
         throws Exception
     {
-        File toBeRemoved = new File( getWorkingDirectory().getAbsolutePath() + File.separator + "toto" );
+        File toBeRemoved = new File( getWorkingDirectory(), "toto" );
         toBeRemoved.mkdir();
 
         ScmFileSet fileSet =  new ScmFileSet( getWorkingCopy(), toBeRemoved );
@@ -69,13 +73,14 @@ public abstract class GitRemoveCommandTckTest
         assertResultIsSuccess( removeResult );
     }
 
+    @Test
     public void testCommandRemoveWithTwoDirectories()
         throws Exception
     {
-        File toBeRemoved1 = new File( getWorkingDirectory().getAbsolutePath() + File.separator + "toto" );
+        File toBeRemoved1 = new File( getWorkingDirectory(), "toto" );
         toBeRemoved1.mkdir();
 
-        File toBeRemoved2 = new File( getWorkingDirectory().getAbsolutePath() + File.separator + "tata" );
+        File toBeRemoved2 = new File( getWorkingDirectory(), "tata" );
         toBeRemoved2.mkdir();
 
         ScmFileSet fileSet =  new ScmFileSet( getWorkingCopy(), Arrays.asList( toBeRemoved1, toBeRemoved2 ) );

--- a/maven-scm-providers/maven-scm-providers-git/maven-scm-provider-jgit/src/main/java/org/apache/maven/scm/provider/git/jgit/JGitScmProvider.java
+++ b/maven-scm-providers/maven-scm-providers-git/maven-scm-provider-jgit/src/main/java/org/apache/maven/scm/provider/git/jgit/JGitScmProvider.java
@@ -41,6 +41,7 @@ import org.apache.maven.scm.provider.git.jgit.command.diff.JGitDiffCommand;
 import org.apache.maven.scm.provider.git.jgit.command.info.JGitInfoCommand;
 import org.apache.maven.scm.provider.git.jgit.command.list.JGitListCommand;
 import org.apache.maven.scm.provider.git.jgit.command.remoteinfo.JGitRemoteInfoCommand;
+import org.apache.maven.scm.provider.git.jgit.command.remove.JGitRemoveCommand;
 import org.apache.maven.scm.provider.git.jgit.command.status.JGitStatusCommand;
 import org.apache.maven.scm.provider.git.jgit.command.tag.JGitTagCommand;
 import org.apache.maven.scm.provider.git.jgit.command.untag.JGitUntagCommand;
@@ -142,7 +143,7 @@ public class JGitScmProvider
     @Override
     protected GitCommand getRemoveCommand()
     {
-        throw new UnsupportedOperationException( "getRemoveCommand" );
+        return new JGitRemoveCommand();
     }
 
     /**

--- a/maven-scm-providers/maven-scm-providers-git/maven-scm-provider-jgit/src/main/java/org/apache/maven/scm/provider/git/jgit/command/JGitUtils.java
+++ b/maven-scm-providers/maven-scm-providers-git/maven-scm-provider-jgit/src/main/java/org/apache/maven/scm/provider/git/jgit/command/JGitUtils.java
@@ -549,13 +549,13 @@ public class JGitUtils
         {
             if ( !file.isAbsolute() )
             {
-                file = new File( fileSet.getBasedir().getPath(), file.getPath() );
+                file = new File( fileSet.getBasedir(), file.getPath() );
             }
 
             if ( file.exists() )
             {
                 URI workingCopyRootUri = git.getRepository().getWorkTree().toURI();
-                String path = FilenameUtils.normalizeFilename( relativize( workingCopyRootUri, file ) );
+                String path = relativize( workingCopyRootUri, file );
                 remove.addFilepattern( path );
             }
         }
@@ -576,8 +576,8 @@ public class JGitUtils
             // really tracked
             for ( Iterator<File> itfl = fileSet.getFileList().iterator(); itfl.hasNext(); )
             {
-                String path = FilenameUtils.normalizeFilename( relativize( baseUri, itfl.next() ) );
-                if ( path.equals( FilenameUtils.normalizeFilename( scmFile.getPath() ) ) )
+                String path = relativize( baseUri, itfl.next() );
+                if ( path.equals( scmFile.getPath() ) )
                 {
                     removedFiles.add( scmFile );
                 }

--- a/maven-scm-providers/maven-scm-providers-git/maven-scm-provider-jgit/src/main/java/org/apache/maven/scm/provider/git/jgit/command/remove/JGitRemoveCommand.java
+++ b/maven-scm-providers/maven-scm-providers-git/maven-scm-provider-jgit/src/main/java/org/apache/maven/scm/provider/git/jgit/command/remove/JGitRemoveCommand.java
@@ -1,0 +1,81 @@
+package org.apache.maven.scm.provider.git.jgit.command.remove;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import java.util.List;
+
+import org.apache.maven.scm.ScmException;
+import org.apache.maven.scm.ScmFile;
+import org.apache.maven.scm.ScmFileSet;
+import org.apache.maven.scm.ScmResult;
+import org.apache.maven.scm.command.remove.AbstractRemoveCommand;
+import org.apache.maven.scm.command.remove.RemoveScmResult;
+import org.apache.maven.scm.provider.ScmProviderRepository;
+import org.apache.maven.scm.provider.git.command.GitCommand;
+import org.apache.maven.scm.provider.git.jgit.command.JGitUtils;
+import org.eclipse.jgit.api.Git;
+
+/**
+ * @author Georg Tsakumagos
+ * @since 2.0.0-M2
+ */
+public class JGitRemoveCommand
+    extends AbstractRemoveCommand
+    implements GitCommand
+{
+
+    @Override
+    protected ScmResult executeRemoveCommand( ScmProviderRepository repository, ScmFileSet fileSet, String message )
+        throws ScmException
+    {
+
+        if ( fileSet.getFileList().isEmpty() )
+        {
+            throw new ScmException( "You must provide at least one file/directory to remove" );
+        }
+        Git git = null;
+        try
+        {
+            git = JGitUtils.openRepo( fileSet.getBasedir() );
+
+            List<ScmFile> removedFiles = JGitUtils.removeAllFiles( git, fileSet );
+
+            if ( logger.isDebugEnabled() )
+            {
+                for ( ScmFile scmFile : removedFiles )
+                {
+                    logger.info( "Removed file: " + scmFile );
+                }
+            }
+
+            return new RemoveScmResult( "JGit remove", removedFiles );
+
+        }
+        catch ( Exception e )
+        {
+            throw new ScmException( "JGit remove failure!", e );
+        }
+        finally
+        {
+            JGitUtils.closeRepo( git );
+        }
+    }
+
+}

--- a/maven-scm-providers/maven-scm-providers-git/maven-scm-provider-jgit/src/test/java/org/apache/maven/scm/provider/git/jgit/command/remove/JGitRemoveCommandTckTest.java
+++ b/maven-scm-providers/maven-scm-providers-git/maven-scm-provider-jgit/src/test/java/org/apache/maven/scm/provider/git/jgit/command/remove/JGitRemoveCommandTckTest.java
@@ -1,4 +1,4 @@
-package org.apache.maven.scm.provider.git.jgit.command.remoteinfo;
+package org.apache.maven.scm.provider.git.jgit.command.remove;
 
 /*
  * Licensed to the Apache Software Foundation (ASF) under one
@@ -22,52 +22,30 @@ package org.apache.maven.scm.provider.git.jgit.command.remoteinfo;
 import java.io.File;
 import java.io.IOException;
 
-import org.apache.maven.scm.command.remoteinfo.RemoteInfoScmResult;
-import org.apache.maven.scm.provider.ScmProviderRepository;
 import org.apache.maven.scm.provider.git.GitScmTestUtils;
-import org.apache.maven.scm.provider.git.command.remoteinfo.AbstractGitRemoteInfoCommandTckTest;
-import org.apache.maven.scm.provider.git.repository.GitScmProviderRepository;
+import org.apache.maven.scm.provider.git.command.remove.GitRemoveCommandTckTest;
 import org.eclipse.jgit.util.FileUtils;
 
-import static org.junit.Assert.assertEquals;
-
 /**
- *
- * @author Dominik Bartholdi (imod)
+ * @author Georg Tsakumagos
  */
-public class JGitRemoteInfoCommandTckTest extends AbstractGitRemoteInfoCommandTckTest
+public class JGitRemoveCommandTckTest
+    extends GitRemoveCommandTckTest
 {
-    @Override
-    protected void checkResult( RemoteInfoScmResult result )
-    {
-        assertEquals( 1, result.getBranches().size() );
-        assertEquals( "92f139dfec4d1dfb79c3cd2f94e83bf13129668b", result.getBranches().get( "master" ) );
-
-        assertEquals( 0, result.getTags().size() );
-    }
-
     /**
      * {@inheritDoc}
      */
     public String getScmUrl()
         throws Exception
     {
-        String scmUrl = GitScmTestUtils.getScmUrl( getRepositoryRoot(), "jgit" );
-        return scmUrl;
-    }
-
-    @Override
-    protected ScmProviderRepository getScmProviderRepository()
-        throws Exception
-    {
-        return new GitScmProviderRepository( getScmUrl().substring( "scm:jgit:".length() ) );
+        return GitScmTestUtils.getScmUrl( getRepositoryRoot(), "jgit" );
     }
 
     @Override
     protected void deleteDirectory( File directory )
         throws IOException
     {
-        if ( directory.exists() )
+        if( directory.exists() )
         {
             FileUtils.delete( directory, FileUtils.RECURSIVE | FileUtils.RETRY );
         }

--- a/pom.xml
+++ b/pom.xml
@@ -378,6 +378,11 @@
     <contributor>
       <name>Niels Basjes</name>
     </contributor>
+    <contributor>
+      <name>Georg Tsakumagos</name>
+      <email>tsakumagos@gmail.com</email>
+      <timezone>Europe/Berlin</timezone>
+    </contributor>
   </contributors>
 
   <profiles>

--- a/src/site/xdoc/matrix.xml
+++ b/src/site/xdoc/matrix.xml
@@ -52,7 +52,7 @@ under the License.
           </tr>
           <tr>
             <!-- SCM -->
-            <td> GIT </td>
+            <td> Git </td>
             <td>
               <!-- add -->
               <img src="./images/check.gif" />


### PR DESCRIPTION
Fourth try to fix [SCM-925]

- Implement remove command for JGit provider
- Write TCK for remove command.
- No other upgrades (Java 1.8 or JGit)
