### PR TITLE
[SCM-988] Ensure Mercurial is installed in Github Actions

### DIFF
--- a/.github/workflows/maven-verify.yml
+++ b/.github/workflows/maven-verify.yml
@@ -25,3 +25,5 @@ jobs:
   build:
     name: Verify
     uses: apache/maven-gh-actions-shared/.github/workflows/maven-verify.yml@v2
+    with:
+      install-mercurial: true


### PR DESCRIPTION
Use the new flag created with https://github.com/apache/maven-gh-actions-shared/pull/45 to install Mercurial during the CI build.