### PR TITLE
[SCM-1009] Wrong scope of maven-compat

### DIFF
--- a/maven-scm-plugin/pom.xml
+++ b/maven-scm-plugin/pom.xml
@@ -61,12 +61,6 @@
     </dependency>
     <dependency>
       <groupId>org.apache.maven</groupId>
-      <artifactId>maven-compat</artifactId>
-      <version>${mavenVersion}</version>
-      <scope>provided</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.maven</groupId>
       <artifactId>maven-settings</artifactId>
       <version>${mavenVersion}</version>
       <scope>provided</scope>
@@ -136,6 +130,12 @@
       <groupId>org.apache.maven.plugin-testing</groupId>
       <artifactId>maven-plugin-testing-harness</artifactId>
       <version>3.3.0</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.maven</groupId>
+      <artifactId>maven-compat</artifactId>
+      <version>${mavenVersion}</version>
       <scope>test</scope>
     </dependency>
     <dependency>


### PR DESCRIPTION
The maven-compat is enlisted as provided dependency of plugin, while it is actually NOT needed at runtime, but due this Maven warns in 3.9.2+.

The maven-compat IS needed, but only in test scope.

---

https://issues.apache.org/jira/browse/SCM-1009