### PR TITLE
[MNG-6829] Replace trimmed StringUtils#isEmpty(String) and #isNotEmpy

### DIFF
--- a/maven-scm-plugin/src/main/java/org/apache/maven/scm/plugin/BootstrapMojo.java
+++ b/maven-scm-plugin/src/main/java/org/apache/maven/scm/plugin/BootstrapMojo.java
@@ -129,7 +129,7 @@ public class BootstrapMojo extends CheckoutMojo {
             }
         }
 
-        if (!StringUtils.isEmpty(this.profiles)) {
+        if (!(this.profiles == null || this.profiles.isEmpty())) {
             cl.createArg().setValue("-P" + this.profiles);
         }
 

--- a/maven-scm-providers/maven-scm-provider-hg/src/main/java/org/apache/maven/scm/provider/hg/command/tag/HgTagCommand.java
+++ b/maven-scm-providers/maven-scm-provider-hg/src/main/java/org/apache/maven/scm/provider/hg/command/tag/HgTagCommand.java
@@ -22,7 +22,6 @@ import java.io.File;
 import java.util.ArrayList;
 import java.util.List;
 
-import org.apache.commons.lang3.StringUtils;
 import org.apache.maven.scm.ScmException;
 import org.apache.maven.scm.ScmFile;
 import org.apache.maven.scm.ScmFileSet;
@@ -64,7 +63,7 @@ public class HgTagCommand extends AbstractTagCommand implements Command {
             ScmTagParameters scmTagParameters)
             throws ScmException {
 
-        if (tag == null || StringUtils.isEmpty(tag.trim())) {
+        if (tag == null || tag.trim().isEmpty()) {
             throw new ScmException("tag must be specified");
         }
 

--- a/maven-scm-providers/maven-scm-providers-git/maven-scm-provider-gitexe/src/main/java/org/apache/maven/scm/provider/git/gitexe/command/branch/GitBranchCommand.java
+++ b/maven-scm-providers/maven-scm-providers-git/maven-scm-provider-gitexe/src/main/java/org/apache/maven/scm/provider/git/gitexe/command/branch/GitBranchCommand.java
@@ -20,7 +20,6 @@ package org.apache.maven.scm.provider.git.gitexe.command.branch;
 
 import java.io.File;
 
-import org.apache.commons.lang3.StringUtils;
 import org.apache.maven.scm.ScmException;
 import org.apache.maven.scm.ScmFileSet;
 import org.apache.maven.scm.ScmFileStatus;
@@ -44,7 +43,7 @@ public class GitBranchCommand extends AbstractBranchCommand implements GitComman
     /** {@inheritDoc} */
     public ScmResult executeBranchCommand(ScmProviderRepository repo, ScmFileSet fileSet, String branch, String message)
             throws ScmException {
-        if (branch == null || StringUtils.isEmpty(branch.trim())) {
+        if (branch == null || branch.trim().isEmpty()) {
             throw new ScmException("branch name must be specified");
         }
 

--- a/maven-scm-providers/maven-scm-providers-git/maven-scm-provider-gitexe/src/main/java/org/apache/maven/scm/provider/git/gitexe/command/tag/GitTagCommand.java
+++ b/maven-scm-providers/maven-scm-providers-git/maven-scm-provider-gitexe/src/main/java/org/apache/maven/scm/provider/git/gitexe/command/tag/GitTagCommand.java
@@ -21,7 +21,6 @@ package org.apache.maven.scm.provider.git.gitexe.command.tag;
 import java.io.File;
 import java.io.IOException;
 
-import org.apache.commons.lang3.StringUtils;
 import org.apache.maven.scm.ScmException;
 import org.apache.maven.scm.ScmFileSet;
 import org.apache.maven.scm.ScmFileStatus;
@@ -55,7 +54,7 @@ public class GitTagCommand extends AbstractTagCommand implements GitCommand {
     public ScmResult executeTagCommand(
             ScmProviderRepository repo, ScmFileSet fileSet, String tag, ScmTagParameters scmTagParameters)
             throws ScmException {
-        if (tag == null || StringUtils.isEmpty(tag.trim())) {
+        if (tag == null || tag.trim().isEmpty()) {
             throw new ScmException("tag name must be specified");
         }
 

--- a/maven-scm-providers/maven-scm-providers-git/maven-scm-provider-gitexe/src/main/java/org/apache/maven/scm/provider/git/gitexe/command/untag/GitUntagCommand.java
+++ b/maven-scm-providers/maven-scm-providers-git/maven-scm-provider-gitexe/src/main/java/org/apache/maven/scm/provider/git/gitexe/command/untag/GitUntagCommand.java
@@ -20,7 +20,6 @@ package org.apache.maven.scm.provider.git.gitexe.command.untag;
 
 import java.io.File;
 
-import org.apache.commons.lang3.StringUtils;
 import org.apache.maven.scm.ScmException;
 import org.apache.maven.scm.ScmFileSet;
 import org.apache.maven.scm.ScmResult;
@@ -41,7 +40,7 @@ public class GitUntagCommand extends AbstractUntagCommand implements GitCommand 
     public ScmResult executeUntagCommand(
             ScmProviderRepository repo, ScmFileSet fileSet, ScmUntagParameters scmUntagParameters) throws ScmException {
         String tag = scmUntagParameters.getTag();
-        if (tag == null || StringUtils.isEmpty(tag.trim())) {
+        if (tag == null || tag.trim().isEmpty()) {
             throw new ScmException("tag name must be specified");
         }
 

--- a/maven-scm-providers/maven-scm-providers-git/maven-scm-provider-jgit/src/main/java/org/apache/maven/scm/provider/git/jgit/command/branch/JGitBranchCommand.java
+++ b/maven-scm-providers/maven-scm-providers-git/maven-scm-provider-jgit/src/main/java/org/apache/maven/scm/provider/git/jgit/command/branch/JGitBranchCommand.java
@@ -24,7 +24,6 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Set;
 
-import org.apache.commons.lang3.StringUtils;
 import org.apache.maven.scm.ScmException;
 import org.apache.maven.scm.ScmFile;
 import org.apache.maven.scm.ScmFileSet;
@@ -58,7 +57,7 @@ public class JGitBranchCommand extends AbstractBranchCommand implements GitComma
     @Override
     protected ScmResult executeBranchCommand(
             ScmProviderRepository repo, ScmFileSet fileSet, String branch, String message) throws ScmException {
-        if (branch == null || StringUtils.isEmpty(branch.trim())) {
+        if (branch == null || branch.trim().isEmpty()) {
             throw new ScmException("branch name must be specified");
         }
 

--- a/maven-scm-providers/maven-scm-providers-git/maven-scm-provider-jgit/src/main/java/org/apache/maven/scm/provider/git/jgit/command/diff/JGitDiffCommand.java
+++ b/maven-scm-providers/maven-scm-providers-git/maven-scm-provider-jgit/src/main/java/org/apache/maven/scm/provider/git/jgit/command/diff/JGitDiffCommand.java
@@ -68,8 +68,7 @@ public class JGitDiffCommand extends AbstractDiffCommand implements GitCommand {
             throws IOException, GitAPIException, ScmException {
 
         AbstractTreeIterator oldTree = null;
-        if (startRevision != null
-                && !startRevision.getName().trim().isEmpty()) {
+        if (startRevision != null && !startRevision.getName().trim().isEmpty()) {
             String startRev = startRevision.getName().trim();
             oldTree = getTreeIterator(git.getRepository(), startRev);
         }

--- a/maven-scm-providers/maven-scm-providers-git/maven-scm-provider-jgit/src/main/java/org/apache/maven/scm/provider/git/jgit/command/diff/JGitDiffCommand.java
+++ b/maven-scm-providers/maven-scm-providers-git/maven-scm-provider-jgit/src/main/java/org/apache/maven/scm/provider/git/jgit/command/diff/JGitDiffCommand.java
@@ -22,7 +22,6 @@ import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
 
-import org.apache.commons.lang3.StringUtils;
 import org.apache.maven.scm.ScmException;
 import org.apache.maven.scm.ScmFileSet;
 import org.apache.maven.scm.ScmVersion;
@@ -70,13 +69,13 @@ public class JGitDiffCommand extends AbstractDiffCommand implements GitCommand {
 
         AbstractTreeIterator oldTree = null;
         if (startRevision != null
-                && StringUtils.isNotEmpty(startRevision.getName().trim())) {
+                && !startRevision.getName().trim().isEmpty()) {
             String startRev = startRevision.getName().trim();
             oldTree = getTreeIterator(git.getRepository(), startRev);
         }
 
         AbstractTreeIterator newTree = null;
-        if (endRevision != null && StringUtils.isNotEmpty(endRevision.getName().trim())) {
+        if (endRevision != null && !endRevision.getName().trim().isEmpty()) {
             String endRev = endRevision.getName().trim();
             newTree = getTreeIterator(git.getRepository(), endRev);
         }

--- a/maven-scm-providers/maven-scm-providers-git/maven-scm-provider-jgit/src/main/java/org/apache/maven/scm/provider/git/jgit/command/tag/JGitTagCommand.java
+++ b/maven-scm-providers/maven-scm-providers-git/maven-scm-provider-jgit/src/main/java/org/apache/maven/scm/provider/git/jgit/command/tag/JGitTagCommand.java
@@ -21,7 +21,6 @@ package org.apache.maven.scm.provider.git.jgit.command.tag;
 import java.util.ArrayList;
 import java.util.List;
 
-import org.apache.commons.lang3.StringUtils;
 import org.apache.maven.scm.ScmException;
 import org.apache.maven.scm.ScmFile;
 import org.apache.maven.scm.ScmFileSet;
@@ -60,7 +59,7 @@ public class JGitTagCommand extends AbstractTagCommand implements GitCommand {
     public ScmResult executeTagCommand(
             ScmProviderRepository repo, ScmFileSet fileSet, String tag, ScmTagParameters scmTagParameters)
             throws ScmException {
-        if (tag == null || StringUtils.isEmpty(tag.trim())) {
+        if (tag == null || tag.trim().isEmpty()) {
             throw new ScmException("tag name must be specified");
         }
 

--- a/maven-scm-providers/maven-scm-providers-git/maven-scm-provider-jgit/src/main/java/org/apache/maven/scm/provider/git/jgit/command/untag/JGitUntagCommand.java
+++ b/maven-scm-providers/maven-scm-providers-git/maven-scm-provider-jgit/src/main/java/org/apache/maven/scm/provider/git/jgit/command/untag/JGitUntagCommand.java
@@ -20,7 +20,6 @@ package org.apache.maven.scm.provider.git.jgit.command.untag;
 
 import java.util.Collection;
 
-import org.apache.commons.lang3.StringUtils;
 import org.apache.maven.scm.ScmException;
 import org.apache.maven.scm.ScmFileSet;
 import org.apache.maven.scm.ScmResult;
@@ -45,7 +44,7 @@ public class JGitUntagCommand extends AbstractUntagCommand implements GitCommand
             ScmProviderRepository repository, ScmFileSet fileSet, ScmUntagParameters scmUntagParameters)
             throws ScmException {
         String tagName = scmUntagParameters.getTag();
-        if (tagName == null || StringUtils.isEmpty(tagName.trim())) {
+        if (tagName == null || tagName.trim().isEmpty()) {
             throw new ScmException("tag name must be specified");
         }
         String escapedTagName = tagName.trim().replace(' ', '_');

--- a/maven-scm-providers/maven-scm-providers-svn/maven-scm-provider-svnexe/src/main/java/org/apache/maven/scm/provider/svn/svnexe/command/branch/SvnBranchCommand.java
+++ b/maven-scm-providers/maven-scm-providers-svn/maven-scm-provider-svnexe/src/main/java/org/apache/maven/scm/provider/svn/svnexe/command/branch/SvnBranchCommand.java
@@ -56,7 +56,7 @@ public class SvnBranchCommand extends AbstractBranchCommand implements SvnComman
     public ScmResult executeBranchCommand(
             ScmProviderRepository repo, ScmFileSet fileSet, String branch, ScmBranchParameters scmBranchParameters)
             throws ScmException {
-        if (branch == null || StringUtils.isEmpty(branch.trim())) {
+        if (branch == null || branch.trim().isEmpty()) {
             throw new ScmException("branch name must be specified");
         }
 

--- a/maven-scm-providers/maven-scm-providers-svn/maven-scm-provider-svnexe/src/main/java/org/apache/maven/scm/provider/svn/svnexe/command/status/SvnStatusConsumer.java
+++ b/maven-scm-providers/maven-scm-providers-svn/maven-scm-provider-svnexe/src/main/java/org/apache/maven/scm/provider/svn/svnexe/command/status/SvnStatusConsumer.java
@@ -22,7 +22,6 @@ import java.io.File;
 import java.util.ArrayList;
 import java.util.List;
 
-import org.apache.commons.lang3.StringUtils;
 import org.apache.maven.scm.ScmFile;
 import org.apache.maven.scm.ScmFileStatus;
 import org.apache.maven.scm.util.AbstractConsumer;
@@ -53,7 +52,7 @@ public class SvnStatusConsumer extends AbstractConsumer {
         if (logger.isDebugEnabled()) {
             logger.debug(line);
         }
-        if (StringUtils.isEmpty(line.trim())) {
+        if (line.trim().isEmpty()) {
             return;
         }
 

--- a/maven-scm-providers/maven-scm-providers-svn/maven-scm-provider-svnexe/src/main/java/org/apache/maven/scm/provider/svn/svnexe/command/tag/SvnTagCommand.java
+++ b/maven-scm-providers/maven-scm-providers-svn/maven-scm-provider-svnexe/src/main/java/org/apache/maven/scm/provider/svn/svnexe/command/tag/SvnTagCommand.java
@@ -76,7 +76,7 @@ public class SvnTagCommand extends AbstractTagCommand implements SvnCommand {
         } else {
             logger.debug("SvnTagCommand :: scmTagParameters.remoteTagging : " + scmTagParameters.isRemoteTagging());
         }
-        if (tag == null || StringUtils.isEmpty(tag.trim())) {
+        if (tag == null || tag.trim().isEmpty()) {
             throw new ScmException("tag must be specified");
         }
 


### PR DESCRIPTION
Additional replacements as compared to https://github.com/apache/maven-scm/pull/169, now also replacing where the input was trimmed.

@elharo would you mind having look at this one and a few to follow? I want to start this up again. :)