### PR TITLE
[SCM-1028] Fix clear password logging vulnerability

### DIFF
--- a/maven-scm-providers/maven-scm-providers-git/maven-scm-provider-git-commons/src/main/java/org/apache/maven/scm/provider/git/repository/GitScmProviderRepository.java
+++ b/maven-scm-providers/maven-scm-providers-git/maven-scm-provider-git-commons/src/main/java/org/apache/maven/scm/provider/git/repository/GitScmProviderRepository.java
@@ -26,6 +26,7 @@ import java.util.regex.Pattern;
 import org.apache.maven.scm.ScmException;
 import org.apache.maven.scm.provider.ScmProviderRepository;
 import org.apache.maven.scm.provider.ScmProviderRepositoryWithHost;
+import org.apache.maven.scm.provider.git.util.GitUtil;
 
 /**
  * @author <a href="mailto:evenisse@apache.org">Emmanuel Venisse</a>
@@ -186,10 +187,24 @@ public class GitScmProviderRepository extends ScmProviderRepositoryWithHost {
     }
 
     /**
+     * @return the URL to fetch from with masked password used for logging purposes only
+     */
+    public String getFetchUrlWithMaskedPassword() {
+        return GitUtil.maskPasswordInUrl(getFetchUrl());
+    }
+
+    /**
      * @return the URL used to push to the upstream repository
      */
     public String getPushUrl() {
         return getUrl(pushInfo);
+    }
+
+    /**
+     * @return the URL to push to with masked password used for logging purposes only
+     */
+    public String getPushUrlWithMaskedPassword() {
+        return GitUtil.maskPasswordInUrl(getPushUrl());
     }
 
     /**
@@ -385,6 +400,7 @@ public class GitScmProviderRepository extends ScmProviderRepositoryWithHost {
     /**
      * {@inheritDoc}
      */
+    @Override
     public String getRelativePath(ScmProviderRepository ancestor) {
         if (ancestor instanceof GitScmProviderRepository) {
             GitScmProviderRepository gitAncestor = (GitScmProviderRepository) ancestor;
@@ -403,11 +419,15 @@ public class GitScmProviderRepository extends ScmProviderRepositoryWithHost {
     /**
      * {@inheritDoc}
      */
+    @Override
     public String toString() {
         // yes we really like to check if those are the exact same instance!
         if (fetchInfo == pushInfo) {
-            return getUrl(fetchInfo);
+            return getFetchUrlWithMaskedPassword();
         }
-        return URL_DELIMITER_FETCH + getUrl(fetchInfo) + URL_DELIMITER_PUSH + getUrl(pushInfo);
+        return URL_DELIMITER_FETCH
+                + getFetchUrlWithMaskedPassword()
+                + URL_DELIMITER_PUSH
+                + getPushUrlWithMaskedPassword();
     }
 }

--- a/maven-scm-providers/maven-scm-providers-git/maven-scm-provider-git-commons/src/test/java/org/apache/maven/scm/provider/git/repository/GitScmProviderRepositoryTest.java
+++ b/maven-scm-providers/maven-scm-providers-git/maven-scm-provider-git-commons/src/test/java/org/apache/maven/scm/provider/git/repository/GitScmProviderRepositoryTest.java
@@ -126,7 +126,7 @@ public class GitScmProviderRepositoryTest extends ScmTestCase {
     public void testLegalHttpURLWithUserPassword() throws Exception {
         testUrl(
                 "scm:git:http://user:password@gitrepos.apache.org",
-                null,
+                "http://user:********@gitrepos.apache.org",
                 "http://user:password@gitrepos.apache.org",
                 null,
                 "user",
@@ -174,7 +174,7 @@ public class GitScmProviderRepositoryTest extends ScmTestCase {
     public void testLegalHttpsURLWithUserPassword() throws Exception {
         testUrl(
                 "scm:git:https://user:password@gitrepos.apache.org",
-                null,
+                "https://user:********@gitrepos.apache.org",
                 "https://user:password@gitrepos.apache.org",
                 null,
                 "user",
@@ -202,7 +202,7 @@ public class GitScmProviderRepositoryTest extends ScmTestCase {
     public void testLegalSshURLWithUserPassword() throws Exception {
         testUrl(
                 "scm:git:ssh://user:password@gitrepos.apache.org",
-                null,
+                "ssh://user:********@gitrepos.apache.org",
                 "ssh://user:password@gitrepos.apache.org",
                 null,
                 "user",
@@ -289,12 +289,12 @@ public class GitScmProviderRepositoryTest extends ScmTestCase {
     public void testSpecialCharacters() throws Exception {
         testUrl(
                 "scm:git:http://gitrepos.apache.org",
-                "@_&_:_?_#_%20",
+                "/_@_&_:_?_#_%20",
                 "pass word",
                 null,
                 "http://gitrepos.apache.org",
                 null,
-                "http://%40_&_:_%3F_%23_%2520:pass%20word@gitrepos.apache.org",
+                "http://%2F_%40_&_:_%3F_%23_%2520:pass%20word@gitrepos.apache.org",
                 null,
                 "gitrepos.apache.org",
                 0,
@@ -303,11 +303,11 @@ public class GitScmProviderRepositoryTest extends ScmTestCase {
         testUrl(
                 "scm:git:http://gitrepos.apache.org",
                 "user name",
-                "@_&_:_?_#_%20",
+                "/_@_&_:_?_#_%20",
                 null,
                 "http://gitrepos.apache.org",
                 null,
-                "http://user%20name:%40_&_:_%3F_%23_%2520@gitrepos.apache.org",
+                "http://user%20name:%2F_%40_&_:_%3F_%23_%2520@gitrepos.apache.org",
                 null,
                 "gitrepos.apache.org",
                 0,
@@ -362,7 +362,7 @@ public class GitScmProviderRepositoryTest extends ScmTestCase {
 
         testUrl(
                 "scm:git:ssh://username:password@gitrepos.apache.org/pmgt/trunk",
-                null,
+                "ssh://username:********@gitrepos.apache.org/pmgt/trunk",
                 "ssh://username:password@gitrepos.apache.org/pmgt/trunk",
                 null,
                 "username",
@@ -376,7 +376,7 @@ public class GitScmProviderRepositoryTest extends ScmTestCase {
     public void testUsernameWithAtAndPasswordInUrl() throws ScmRepositoryException, Exception {
         testUrl(
                 "scm:git:http://username@site.com:password@gitrepos.apache.org:8800/pmgt/trunk",
-                null,
+                "http://username%40site.com:********@gitrepos.apache.org:8800/pmgt/trunk",
                 "http://username%40site.com:password@gitrepos.apache.org:8800/pmgt/trunk",
                 null,
                 "username@site.com",
@@ -394,7 +394,7 @@ public class GitScmProviderRepositoryTest extends ScmTestCase {
     public void testHttpFetchSshPushUrl() throws Exception {
         testUrl(
                 "scm:git:[fetch=]http://git.apache.org/myprj.git[push=]ssh://myuser:mypassword@git.apache.org/~/myrepo/myprj.git",
-                "[fetch=]http://myuser:mypassword@git.apache.org/myprj.git[push=]ssh://myuser:mypassword@git.apache.org/~/myrepo/myprj.git",
+                "[fetch=]http://myuser:********@git.apache.org/myprj.git[push=]ssh://myuser:********@git.apache.org/~/myrepo/myprj.git",
                 "http://myuser:mypassword@git.apache.org/myprj.git",
                 "ssh://myuser:mypassword@git.apache.org/~/myrepo/myprj.git",
                 "myuser",
@@ -405,7 +405,7 @@ public class GitScmProviderRepositoryTest extends ScmTestCase {
 
         testUrl(
                 "scm:git:[push=]ssh://myuser:mypassword@git.apache.org/~/myrepo/myprj.git[fetch=]http://git.apache.org/myprj.git",
-                "[fetch=]http://myuser:mypassword@git.apache.org/myprj.git[push=]ssh://myuser:mypassword@git.apache.org/~/myrepo/myprj.git",
+                "[fetch=]http://myuser:********@git.apache.org/myprj.git[push=]ssh://myuser:********@git.apache.org/~/myrepo/myprj.git",
                 "http://myuser:mypassword@git.apache.org/myprj.git",
                 "ssh://myuser:mypassword@git.apache.org/~/myrepo/myprj.git",
                 "myuser",

--- a/maven-scm-providers/maven-scm-providers-git/maven-scm-provider-gitexe/src/main/java/org/apache/maven/scm/provider/git/gitexe/command/AnonymousCommandLine.java
+++ b/maven-scm-providers/maven-scm-providers-git/maven-scm-provider-gitexe/src/main/java/org/apache/maven/scm/provider/git/gitexe/command/AnonymousCommandLine.java
@@ -18,9 +18,7 @@
  */
 package org.apache.maven.scm.provider.git.gitexe.command;
 
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
-
+import org.apache.maven.scm.provider.git.util.GitUtil;
 import org.codehaus.plexus.util.cli.Commandline;
 
 /**
@@ -29,10 +27,6 @@ import org.codehaus.plexus.util.cli.Commandline;
  */
 public class AnonymousCommandLine extends Commandline {
 
-    public static final String PASSWORD_PLACE_HOLDER = "********";
-
-    private Pattern passwordPattern = Pattern.compile("^.*:(.*)@.*$");
-
     /**
      * Provides an anonymous output to mask password. Considering URL of type :
      * &lt;&lt;protocol&gt;&gt;://&lt;&lt;user&gt;&gt;:&lt;&lt;password&gt;&gt;@
@@ -40,14 +34,7 @@ public class AnonymousCommandLine extends Commandline {
      */
     @Override
     public String toString() {
-        String output = super.toString();
-        final Matcher passwordMatcher = passwordPattern.matcher(output);
-        if (passwordMatcher.find()) {
-            // clear password
-            final String clearPassword = passwordMatcher.group(1);
-            // to be replaced in output by stars
-            output = output.replace(clearPassword, PASSWORD_PLACE_HOLDER);
-        }
+        String output = GitUtil.maskPasswordInUrl(super.toString());
         return output;
     }
 }

--- a/maven-scm-providers/maven-scm-providers-git/maven-scm-provider-gitexe/src/main/java/org/apache/maven/scm/provider/git/gitexe/command/remoteinfo/GitRemoteInfoCommand.java
+++ b/maven-scm-providers/maven-scm-providers-git/maven-scm-provider-gitexe/src/main/java/org/apache/maven/scm/provider/git/gitexe/command/remoteinfo/GitRemoteInfoCommand.java
@@ -56,7 +56,7 @@ public class GitRemoteInfoCommand extends AbstractRemoteInfoCommand implements G
 
         int exitCode = GitCommandLineUtils.execute(clLsRemote, consumer, stderr);
         if (exitCode != 0) {
-            throw new ScmException("unable to execute ls-remote on " + gitRepository.getFetchUrl());
+            throw new ScmException("unable to execute ls-remote on " + gitRepository.getFetchUrlWithMaskedPassword());
         }
 
         return consumer.getRemoteInfoScmResult();

--- a/maven-scm-providers/maven-scm-providers-git/maven-scm-provider-gitexe/src/test/java/org/apache/maven/scm/provider/git/gitexe/command/GitCommandLineUtilsTest.java
+++ b/maven-scm-providers/maven-scm-providers-git/maven-scm-provider-gitexe/src/test/java/org/apache/maven/scm/provider/git/gitexe/command/GitCommandLineUtilsTest.java
@@ -28,6 +28,7 @@ import java.util.Map;
 
 import org.apache.maven.scm.ScmException;
 import org.apache.maven.scm.provider.git.repository.GitScmProviderRepository;
+import org.apache.maven.scm.provider.git.util.GitUtil;
 import org.codehaus.plexus.util.Os;
 import org.codehaus.plexus.util.cli.Commandline;
 import org.junit.Test;
@@ -91,13 +92,13 @@ public class GitCommandLineUtilsTest {
             assertFalse(
                     MessageFormat.format(
                             "The target log message should not contain <{0}> but it contains <{1}>",
-                            AnonymousCommandLine.PASSWORD_PLACE_HOLDER, commandLineArgs[i]),
-                    commandLineArgs[i].contains(AnonymousCommandLine.PASSWORD_PLACE_HOLDER));
+                            GitUtil.PASSWORD_PLACE_HOLDER_WITH_DELIMITERS, commandLineArgs[i]),
+                    commandLineArgs[i].contains(GitUtil.PASSWORD_PLACE_HOLDER_WITH_DELIMITERS));
         }
 
-        final String scmUrlFakeForTest = "https://user:"
-                .concat(AnonymousCommandLine.PASSWORD_PLACE_HOLDER)
-                .concat("@foo.com/git/trunk");
+        final String scmUrlFakeForTest = "https://user"
+                .concat(GitUtil.PASSWORD_PLACE_HOLDER_WITH_DELIMITERS)
+                .concat("foo.com/git/trunk");
 
         assertTrue(
                 MessageFormat.format(

--- a/maven-scm-providers/maven-scm-providers-git/maven-scm-provider-jgit/src/main/java/org/apache/maven/scm/provider/git/jgit/command/JGitUtils.java
+++ b/maven-scm-providers/maven-scm-providers-git/maven-scm-provider-jgit/src/main/java/org/apache/maven/scm/provider/git/jgit/command/JGitUtils.java
@@ -20,8 +20,6 @@ package org.apache.maven.scm.provider.git.jgit.command;
 
 import java.io.File;
 import java.io.IOException;
-import java.io.UnsupportedEncodingException;
-import java.net.URLEncoder;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Date;
@@ -132,7 +130,7 @@ public class JGitUtils {
      * @param git        the instance to configure (only in memory, not saved)
      * @param repository the repo config to be used
      * @return {@link CredentialsProvider} in case there are credentials
-     *         informations configured in the repository.
+     * informations configured in the repository.
      */
     public static CredentialsProvider prepareSession(Git git, GitScmProviderRepository repository) {
         StoredConfig config = git.getRepository().getConfig();
@@ -140,20 +138,8 @@ public class JGitUtils {
         config.setString("remote", "origin", "pushURL", repository.getPushUrl());
 
         // make sure we do not log any passwords to the output
-        String password = StringUtils.isNotBlank(repository.getPassword())
-                ? repository.getPassword().trim()
-                : "no-pwd-defined";
-        // if password contains special characters it won't match below.
-        // Try encoding before match. (Passwords without will be unaffected)
-        try {
-            password = URLEncoder.encode(password, "UTF-8");
-        } catch (UnsupportedEncodingException e) {
-            // UTF-8 should be valid
-            // TODO use a logger
-            System.out.println("Ignore UnsupportedEncodingException when trying to encode password");
-        }
-        LOGGER.info("fetch url: " + repository.getFetchUrl().replace(password, "******"));
-        LOGGER.info("push url: " + repository.getPushUrl().replace(password, "******"));
+        LOGGER.info("fetch url: " + repository.getFetchUrlWithMaskedPassword());
+        LOGGER.info("push url: " + repository.getPushUrlWithMaskedPassword());
         return getCredentials(repository);
     }
 


### PR DESCRIPTION
## JIRA
[SCM-1028](https://issues.apache.org/jira/browse/SCM-1028) Vulnerability: Clear text password is logged by JGit provider and by gitexe remoteinfo on a ls-remote failure

## Changes
- GitUtil.java:
  - add method maskPasswordInUrl(String urlWithCredentials)
    - implementation taken from AnonymousCommandLine.java
    - improve regex pattern to be more precise
    - replace wrapped with delimiters ':' and '@' to avoid replacing the password within probable other places of the URL to avoid password guessing by using e.g. redundant URL parameters

- AnonymousCommandLine.java:
  - move current password masking implementation to GitUtil
  - use implementation from GitUtil

- GitScmProviderRepository.java:
  - add method getFetchUrlWithMaskedPassword()
  - add method getPushUrlWithMaskedPassword()
  - toString():
    - 👉 **BREAKING** change: provide URL content with masked password to reduce risk of usage within logs or exceptions with showing passwords by that

- JGitUtils.java:
  - method prepareSession(Git git, GitScmProviderRepository repository):
    - log using methods:
      - GitScmProviderRepository.getFetchUrlWithMaskedPassword()
      - GitScmProviderRepository.getPushUrlWithMaskedPassword()

- GitRemoteInfoCommand.java:
  - use GitScmProviderRepository.getFetchUrlWithMaskedPassword() for exception message

- Update JUnit tests accordingly:
  - GitScmProviderRepositoryTest.java
  - GitCommandLineUtilsTest.java

## Test result
- All JUnit tests passed
