### PR TITLE
[SCM-1029] Fix empty commits on JGit checkin

### DIFF
--- a/maven-scm-providers/maven-scm-providers-git/maven-scm-provider-jgit/src/main/java/org/apache/maven/scm/provider/git/jgit/command/checkin/JGitCheckInCommand.java
+++ b/maven-scm-providers/maven-scm-providers-git/maven-scm-provider-jgit/src/main/java/org/apache/maven/scm/provider/git/jgit/command/checkin/JGitCheckInCommand.java
@@ -89,7 +89,10 @@ public class JGitCheckInCommand extends AbstractCheckInCommand implements GitCom
                 // add files first
                 doCommit = JGitUtils.addAllFiles(git, fileSet).size() > 0;
                 if (!doCommit) {
-                    doCommit = git.status().call().hasUncommittedChanges();
+                    Status status = git.status().call();
+                    doCommit = status.getAdded().size() > 0
+                            || status.getChanged().size() > 0
+                            || status.getRemoved().size() > 0;
                 }
             } else {
                 // add all tracked files which are modified manually
@@ -132,6 +135,8 @@ public class JGitCheckInCommand extends AbstractCheckInCommand implements GitCom
                         logger.debug("in commit: " + scmFile);
                     }
                 }
+            } else {
+                logger.info("nothing to commit");
             }
 
             if (repo.isPushChanges()) {


### PR DESCRIPTION
## JIRA
[SCM-1029](https://issues.apache.org/jira/browse/SCM-1029)

## Changes
- JGitCheckInCommand.java:
  - in case of a includes / excludes FileSet is specified then:
    - use OR condition of
      - status.getAdded().size() > 0
      - status.getChanged().size() > 0
      - status.getRemoved() > 0
     
     instead of status.hasUncommittedChanges()
  - log info "nothing to commit" if nothing is to be commited

## Test
- All JUnit tests passed
- Tested in a local application