### PR TITLE
Add shallow parameter to checkout mojo

### DIFF
--- a/maven-scm-plugin/src/main/java/org/apache/maven/scm/plugin/CheckoutMojo.java
+++ b/maven-scm-plugin/src/main/java/org/apache/maven/scm/plugin/CheckoutMojo.java
@@ -26,6 +26,8 @@ import java.io.IOException;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.Parameter;
+import org.apache.maven.scm.CommandParameter;
+import org.apache.maven.scm.CommandParameters;
 import org.apache.maven.scm.ScmException;
 import org.apache.maven.scm.ScmFileSet;
 import org.apache.maven.scm.ScmResult;
@@ -72,6 +74,14 @@ public class CheckoutMojo extends AbstractScmMojo {
     private String scmVersion;
 
     /**
+     * Currently only implemented with Git Executable. Perform a shallow checkout.
+     *
+     * @since 2.1.1
+     */
+    @Parameter(property = "shallow", defaultValue = "false")
+    private boolean shallow = false;
+
+    /**
      * allow extended mojo (ie BootStrap ) to see checkout result
      */
     private ScmResult checkoutResult;
@@ -116,7 +126,12 @@ public class CheckoutMojo extends AbstractScmMojo {
             if (useExport) {
                 result = getScmManager().export(repository, fileSet, getScmVersion(scmVersionType, scmVersion));
             } else {
-                result = getScmManager().checkOut(repository, fileSet, getScmVersion(scmVersionType, scmVersion));
+                CommandParameters parameters = new CommandParameters();
+                parameters.setString(CommandParameter.RECURSIVE, Boolean.toString(true));
+                parameters.setString(CommandParameter.SHALLOW, Boolean.toString(shallow));
+                result = getScmManager()
+                        .getProviderByRepository(repository)
+                        .checkOut(repository, fileSet, getScmVersion(scmVersionType, scmVersion), parameters);
             }
 
             checkResult(result);


### PR DESCRIPTION
Addresses #1263.

Adds an optional boolean `shallow` parameter to the checkout mojo (it is disabled by default).

When enabled, it adds `--depth 1` to the git clone command line.

Following this checklist to help us incorporate your
contribution quickly and easily:

- [x] Your pull request should address just one issue, without pulling in other changes.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Each commit in the pull request should have a meaningful subject line and body.
  Note that commits might be squashed by a maintainer on merge.
- [ ] Write unit tests that match behavioral changes, where the tests fail if the changes to the runtime are not applied.
  This may not always be possible but is a best-practice.
- [x] Run `mvn verify` to make sure basic checks pass.
  A more thorough check will be performed on your pull request automatically.
- [x] You have run the integration tests successfully (`mvn -Prun-its verify`).

If your pull request is about ~20 lines of code you don't need to sign an
[Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf) if you are unsure
please ask on the developers list.

To make clear that you license your contribution under
the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
you have to acknowledge this by using the following check-box.

- [x] I hereby declare this contribution to be licenced under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
- [ ] In any other case, please file an [Apache Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).
