### PR TITLE
Throw is enough

### DIFF
--- a/maven-scm-plugin/src/main/java/org/apache/maven/scm/plugin/CheckLocalModificationsMojo.java
+++ b/maven-scm-plugin/src/main/java/org/apache/maven/scm/plugin/CheckLocalModificationsMojo.java
@@ -81,7 +81,6 @@ public class CheckLocalModificationsMojo extends AbstractScmMojo {
         }
 
         if (!result.getChangedFiles().isEmpty()) {
-            getLog().error(errorMessage);
             throw new MojoExecutionException(errorMessage);
         }
     }

--- a/maven-scm-plugin/src/main/java/org/apache/maven/scm/plugin/TagMojo.java
+++ b/maven-scm-plugin/src/main/java/org/apache/maven/scm/plugin/TagMojo.java
@@ -140,7 +140,6 @@ public class TagMojo extends AbstractScmMojo {
                     getLog().info("Using timestamp '" + tagTimestamp + "'");
                 } catch (IllegalArgumentException e) {
                     String msg = "The timestamp format '" + timestampFormat + "' is invalid.";
-                    getLog().error(msg, e);
                     throw new MojoExecutionException(msg, e);
                 }
 


### PR DESCRIPTION
The MojoExecutionException will be logged as needed. No need to double log it with an identical message