### PR TITLE
Document deprecation rationale for executeChangeLogCommand overloads

### DIFF
--- a/maven-scm-api/src/main/java/org/apache/maven/scm/command/changelog/AbstractChangeLogCommand.java
+++ b/maven-scm-api/src/main/java/org/apache/maven/scm/command/changelog/AbstractChangeLogCommand.java
@@ -35,6 +35,13 @@ import org.apache.maven.scm.provider.ScmProviderRepository;
  * @author Olivier Lamy
  */
 public abstract class AbstractChangeLogCommand extends AbstractCommand implements ChangeLogCommand {
+    /**
+     * @deprecated This method is part of the legacy changelog command execution
+     * mechanism and is retained for backward compatibility with existing SCM
+     * provider implementations. Some providers (for example Git) still implement
+     * this API, but newer code should rely on the current changelog handling
+     * logic provided by the SCM command framework instead.
+     */
     @Deprecated
     protected abstract ChangeLogScmResult executeChangeLogCommand(
             ScmProviderRepository repository,
@@ -45,6 +52,12 @@ public abstract class AbstractChangeLogCommand extends AbstractCommand implement
             String datePattern)
             throws ScmException;
 
+    /**
+     * @deprecated This legacy overload is kept for backward compatibility.
+     * It may not be supported by all SCM providers and in many cases
+     * results in an {@link ScmException}. Providers that still rely on it
+     * should consider migrating to the newer changelog execution APIs.
+     */
     @Deprecated
     protected ChangeLogScmResult executeChangeLogCommand(
             ScmProviderRepository repository,
@@ -56,6 +69,12 @@ public abstract class AbstractChangeLogCommand extends AbstractCommand implement
         throw new ScmException("Unsupported method for this provider.");
     }
 
+    /**
+     * @deprecated This legacy overload is kept for backward compatibility.
+     * It may not be supported by all SCM providers and in many cases
+     * results in an {@link ScmException}. Providers that still rely on it
+     * should consider migrating to the newer changelog execution APIs.
+     */
     @Deprecated
     protected ChangeLogScmResult executeChangeLogCommand(
             ScmProviderRepository repository, ScmFileSet fileSet, ScmVersion version, String datePattern)


### PR DESCRIPTION
Fixes #1344

Documents the rationale for the deprecation of the legacy
executeChangeLogCommand methods in AbstractChangeLogCommand and clarifies
that they are retained only for backward compatibility with existing SCM
provider implementations.

No functional behavior is changed. These methods remain deprecated and are
not recommended for use by new implementations.

Following this checklist to help us incorporate your
contribution quickly and easily:

- [x] Your pull request should address just one issue, without pulling in other changes.
- [ ] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Each commit in the pull request should have a meaningful subject line and body.
  Note that commits might be squashed by a maintainer on merge.
- [ ] Write unit tests that match behavioral changes, where the tests fail if the changes to the runtime are not applied.
  This may not always be possible but is a best-practice.
- [x] Run `mvn verify` to make sure basic checks pass.
  A more thorough check will be performed on your pull request automatically.
- [ ] You have run the integration tests successfully (`mvn -Prun-its verify`).

If your pull request is about ~20 lines of code you don't need to sign an
[Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf) if you are unsure
please ask on the developers list.

To make clear that you license your contribution under
the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
you have to acknowledge this by using the following check-box.

- [x] I hereby declare this contribution to be licenced under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
- [ ] In any other case, please file an [Apache Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).
