### PR TITLE
JGitStatusCommand: filter results by fileSet.getFileList() if not empty

### DIFF
--- a/maven-scm-providers/maven-scm-providers-git/maven-scm-provider-jgit/src/main/java/org/apache/maven/scm/provider/git/jgit/command/status/JGitStatusCommand.java
+++ b/maven-scm-providers/maven-scm-providers-git/maven-scm-provider-jgit/src/main/java/org/apache/maven/scm/provider/git/jgit/command/status/JGitStatusCommand.java
@@ -55,7 +55,8 @@ public class JGitStatusCommand extends AbstractStatusCommand implements GitComma
             Status status = git.status().call();
             List<ScmFile> changedFiles = getFileStati(status);
             if (!fileSet.getFileList().isEmpty()) {
-                Set<String> fileSetPaths = fileSet.getFileList().stream().map(File::toString).collect(Collectors.toSet());
+                Set<String> fileSetPaths =
+                        fileSet.getFileList().stream().map(File::toString).collect(Collectors.toSet());
                 changedFiles.removeIf(scmFile -> !fileSetPaths.contains(scmFile.getPath()));
             }
             return new StatusScmResult("JGit status", changedFiles);

--- a/maven-scm-providers/maven-scm-providers-git/maven-scm-provider-jgit/src/main/java/org/apache/maven/scm/provider/git/jgit/command/status/JGitStatusCommand.java
+++ b/maven-scm-providers/maven-scm-providers-git/maven-scm-provider-jgit/src/main/java/org/apache/maven/scm/provider/git/jgit/command/status/JGitStatusCommand.java
@@ -18,10 +18,13 @@
  */
 package org.apache.maven.scm.provider.git.jgit.command.status;
 
+import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 import org.apache.maven.scm.ScmException;
 import org.apache.maven.scm.ScmFile;
@@ -51,7 +54,10 @@ public class JGitStatusCommand extends AbstractStatusCommand implements GitComma
             git = JGitUtils.openRepo(fileSet.getBasedir());
             Status status = git.status().call();
             List<ScmFile> changedFiles = getFileStati(status);
-
+            if (!fileSet.getFileList().isEmpty()) {
+                Set<String> fileSetPaths = fileSet.getFileList().stream().map(File::toString).collect(Collectors.toSet());
+                changedFiles.removeIf(scmFile -> !fileSetPaths.contains(scmFile.getPath()));
+            }
             return new StatusScmResult("JGit status", changedFiles);
         } catch (IOException | GitAPIException e) {
             throw new ScmException("JGit status failure!", e);


### PR DESCRIPTION
JGitStatusCommand currently ignores fileSet.getFileList() and always returns the full repository status.  
This causes inconsistent behavior compared to the gitexe provider, where GitStatusConsumer correctly filters results to only the requested files.

This PR fixes JGitStatusCommand to apply the same file-list filtering, so both providers behave consistently when a FileSet with specific files is supplied.

Testing: This case is not covered by the TCK

I hereby declare this contribution to be licenced under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)