### PR TITLE
Repair the SCM overview table

### DIFF
--- a/src/site/markdown/scms-overview.md
+++ b/src/site/markdown/scms-overview.md
@@ -27,14 +27,13 @@ date: 2005-12-01
 
 These SCMs are supported with their providers shipping with maven-scm
 
-|   |   |   |
-|:---:|:---:|:---:|
-|**SCM**|**Provider ID**|**Provider Module**|**Native Java**
-|[Git](./git.html)|`git`|[Git Executable Provider](./maven-scm-providers/maven-scm-providers-git/maven-scm-provider-gitexe/index.html)|no
-|[Git](./git.html)|`jgit`|[JGit Provider](./maven-scm-providers/maven-scm-providers-git/maven-scm-provider-jgit/index.html)|yes
-|[Subversion](./subversion.html)|`svn`|[SVN Executable Provider](./maven-scm-providers/maven-scm-providers-svn/maven-scm-provider-svnexe/index.html)|no
-|[Mercurial](./mercurial.html)|`hg`|[Mercurial \(Hg\) Provider](./maven-scm-providers/maven-scm-provider-hg/index.html)|no
-|[Local](./local.html)|`local`|[Local Provider](./maven-scm-providers/maven-scm-provider-local/index.html)|yes
+|**SCM**|**Provider ID**|**Provider Module**|**Native Java**|
+|:---:|:---:|:---:|:---:|
+|[Git](./git.html)|`git`|[Git Executable Provider](./maven-scm-providers/maven-scm-providers-git/maven-scm-provider-gitexe/index.html)|no|
+|[Git](./git.html)|`jgit`|[JGit Provider](./maven-scm-providers/maven-scm-providers-git/maven-scm-provider-jgit/index.html)|yes|
+|[Subversion](./subversion.html)|`svn`|[SVN Executable Provider](./maven-scm-providers/maven-scm-providers-svn/maven-scm-provider-svnexe/index.html)|no|
+|[Mercurial](./mercurial.html)|`hg`|[Mercurial \(Hg\) Provider](./maven-scm-providers/maven-scm-provider-hg/index.html)|no|
+|[Local](./local.html)|`local`|[Local Provider](./maven-scm-providers/maven-scm-provider-local/index.html)|yes|
 
 ## 3rd Party SCM Providers
 


### PR DESCRIPTION
The table lost its fourth column when the page was migrated from APT. An empty
row stood in as the header with a three column separator under it, so the real
header and every data row carried one cell more than the separator allowed and
the "Native Java" column was dropped from the rendered page.

The real header row is now the header, the separator has four columns, and the
rows have their closing pipe.

Verified by building the site: the table renders four columns.


Part of the wider migration tracked in
https://github.com/apache/maven-doxia-converter/issues/139
