### PR TITLE
Drop backslash escapes that Markdown does not need

### DIFF
--- a/maven-scm-plugin/src/site/markdown/usage.md
+++ b/maven-scm-plugin/src/site/markdown/usage.md
@@ -25,8 +25,8 @@ date: 2008-08-13
 
 The SCM Plugin maps a lot of commands to a variety of SCM implementations. But there are only 2 frequently used commands:
 
-- `checkin` - commit the changes to the remote repository \( SCM server \).
-- `update` - updates the local working copy with the one from the remote repository \( SCM server \).
+- `checkin` - commit the changes to the remote repository ( SCM server ).
+- `update` - updates the local working copy with the one from the remote repository ( SCM server ).
 
 # Configuring SCM
 

--- a/src/site/markdown/git.md
+++ b/src/site/markdown/git.md
@@ -31,7 +31,7 @@ License: GNU General Public License v2
 
 ## SCM URL
 
-For all URLs below, we use a colon \(:\) as separator. If you use a colon for one of the variables \(e.g. a windows path\), then use a pipe \(|\) as separator. The separator for the port has to be a colon in any case since this part is specified in the [Git URL specification](https://git-scm.com/docs/git-clone#_git_urls).
+For all URLs below, we use a colon (:) as separator. If you use a colon for one of the variables (e.g. a windows path), then use a pipe (|) as separator. The separator for the port has to be a colon in any case since this part is specified in the [Git URL specification](https://git-scm.com/docs/git-clone#_git_urls).
 
 ```
 scm:git:git://server_name[:port]/path_to_repository

--- a/src/site/markdown/guide/new_provider.md
+++ b/src/site/markdown/guide/new_provider.md
@@ -81,7 +81,7 @@ The Sisu Maven Plugin will generate the components meta-data file used by the DI
 
 ## Create an SCM Provider Repository class
 
-This class will contain all SCM information about your SCM connection \(user, password, host, port, path...\).
+This class will contain all SCM information about your SCM connection (user, password, host, port, path...).
 
 ```unknown
 package org.apache.maven.scm.provider.myprovider.repository;
@@ -139,7 +139,7 @@ public class MyScmProvider
 }
 ```
 
-The JSR330 annotations will be used by the Sisu Maven Plugin, declared in the POM, to generate component meta-data. Generally, we use the string just after _scm:_ in the scm URL as the _provider\_name_.
+The JSR330 annotations will be used by the Sisu Maven Plugin, declared in the POM, to generate component meta-data. Generally, we use the string just after _scm:_ in the scm URL as the _provider_name_.
 
 ## Commands implementation
 
@@ -168,7 +168,7 @@ public class MyCheckoutCommand
 
 ## Allow the command in the SCM provider
 
-Now that your command is implemented, you need to add it in your SCM provider \(`MyScmProvider`\). Open the provider class and override the method that relates to your command.
+Now that your command is implemented, you need to add it in your SCM provider (`MyScmProvider`). Open the provider class and override the method that relates to your command.
 
 ```unknown
 public class MyScmProvider
@@ -202,5 +202,5 @@ It&apos;s important to test your SCM provider with these tools, because they are
 
 ## Document your provider
 
-Now that your provider works fine, you must document it \(which scm URLs are supported, which commands are supported...\). You can use the same template that is used by the other providers.
+Now that your provider works fine, you must document it (which scm URLs are supported, which commands are supported...). You can use the same template that is used by the other providers.
 

--- a/src/site/markdown/index.md
+++ b/src/site/markdown/index.md
@@ -23,7 +23,7 @@ date: 2013-10-27
 <!-- under the License.-->
 # Maven SCM
 
-Maven SCM supports Maven plugins \(for example [maven-release-plugin](https://maven.apache.org/plugins/maven-release-plugin/)\) and other tools by providing them with [a common API](./maven-scm-api/apidocs) for source code management operations. You can look at [the list of SCMs](./scms-overview.html) for more information on using Maven SCM with your favorite SCM tool.
+Maven SCM supports Maven plugins (for example [maven-release-plugin](https://maven.apache.org/plugins/maven-release-plugin/)) and other tools by providing them with [a common API](./maven-scm-api/apidocs) for source code management operations. You can look at [the list of SCMs](./scms-overview.html) for more information on using Maven SCM with your favorite SCM tool.
 
 In addition, Maven SCM provides two tools to directly use it:
 

--- a/src/site/markdown/local.md
+++ b/src/site/markdown/local.md
@@ -31,15 +31,15 @@ License: -
 
 ## SCM URL
 
-For all URLs below, we use a colon \(:\) as separator. If you use a colon for one of the variables \(e.g. a windows path\), then use a pipe \(|\) as separator.
+For all URLs below, we use a colon (:) as separator. If you use a colon for one of the variables (e.g. a windows path), then use a pipe (|) as separator.
 
 ```
 scm:local<delimiter>path_to_repository<delimiter>module_name
 ```
 
-_path\_to\_repository_: The absolute or relative path to the parent directory of your pom.xml
+_path_to_repository_: The absolute or relative path to the parent directory of your pom.xml
 
-_module\_name_: The name of the directory that contains your pom.xml
+_module_name_: The name of the directory that contains your pom.xml
 
 ## Examples
 

--- a/src/site/markdown/scm-commands.md
+++ b/src/site/markdown/scm-commands.md
@@ -31,7 +31,7 @@ Adds a new file to the source control system
 
 ## Changelog
 
-Produces a list of changed \(a new version has been put in the system\) files. This list can then be used to display the latest changes or the developer\(s\) who did the latest changes.
+Produces a list of changed (a new version has been put in the system) files. This list can then be used to display the latest changes or the developer(s) who did the latest changes.
 
 ## Checkin
 
@@ -39,7 +39,7 @@ Save the changes you have done into the repository. This will create a new versi
 
 ## Checkout
 
-Copy \(part of\) the contents of the source control system to a certain location on your local machine. It should be possible to scm operations in that location.
+Copy (part of) the contents of the source control system to a certain location on your local machine. It should be possible to scm operations in that location.
 
 ## Edit
 
@@ -55,11 +55,11 @@ Removes a file from the source control system
 
 ## Status
 
-Gives a list of files that still need some source control operation \(files that still need to be added, files that are in edit mode, ...\)
+Gives a list of files that still need some source control operation (files that still need to be added, files that are in edit mode, ...)
 
 ## Tag
 
-Tags \(label in some scm&apos;s\) a source tree with a certain tag. This allows to make reproducable builds later by checking out the source code that has this tag.
+Tags (label in some scm&apos;s) a source tree with a certain tag. This allows to make reproducable builds later by checking out the source code that has this tag.
 
 ## Update
 

--- a/src/site/markdown/scm-url-format.md
+++ b/src/site/markdown/scm-url-format.md
@@ -31,7 +31,7 @@ The general format for an SCM URL is
 scm:<provider id><delimiter><provider-specific part>
 ```
 
-For a delimiter, you can use either colon `:` or a pipe `|`, if you use a colon for one of the variables \(e.g. a Windows path\).
+For a delimiter, you can use either colon `:` or a pipe `|`, if you use a colon for one of the variables (e.g. a Windows path).
 
 For information about supported provider IDs and the provider-specific part, see the appropriate [SCM implementation](./scms-overview.html).
 

--- a/src/site/markdown/scms-overview.md
+++ b/src/site/markdown/scms-overview.md
@@ -32,7 +32,7 @@ These SCMs are supported with their providers shipping with maven-scm
 |[Git](./git.html)|`git`|[Git Executable Provider](./maven-scm-providers/maven-scm-providers-git/maven-scm-provider-gitexe/index.html)|no|
 |[Git](./git.html)|`jgit`|[JGit Provider](./maven-scm-providers/maven-scm-providers-git/maven-scm-provider-jgit/index.html)|yes|
 |[Subversion](./subversion.html)|`svn`|[SVN Executable Provider](./maven-scm-providers/maven-scm-providers-svn/maven-scm-provider-svnexe/index.html)|no|
-|[Mercurial](./mercurial.html)|`hg`|[Mercurial \(Hg\) Provider](./maven-scm-providers/maven-scm-provider-hg/index.html)|no|
+|[Mercurial](./mercurial.html)|`hg`|[Mercurial (Hg) Provider](./maven-scm-providers/maven-scm-provider-hg/index.html)|no|
 |[Local](./local.html)|`local`|[Local Provider](./maven-scm-providers/maven-scm-provider-local/index.html)|yes|
 
 ## 3rd Party SCM Providers

--- a/src/site/markdown/subversion.md
+++ b/src/site/markdown/subversion.md
@@ -32,7 +32,7 @@ License: Apache License, Version 2\.0
 
 ## SCM URL
 
-For all URLs below, we use a colon \(:\) as separator. If you use a colon for one of the variables \(e.g. a windows path\), then use a pipe \(|\) as separator.
+For all URLs below, we use a colon (:) as separator. If you use a colon for one of the variables (e.g. a windows path), then use a pipe (|) as separator.
 
 ```
 scm:svn:svn://[username[:password]@]server_name[:port]/path_to_repository
@@ -59,7 +59,7 @@ The provider configuration is defined in `${user.home}/.scm/svn-settings.xml`. F
 
 ### Configuration directory
 
-You can define the subversion configuration directory \(&apos;--config-dir&apos; svn global option\) in the provider configuration file or with &apos;maven.scm.svn.config\_directory&apos; command line parameter.
+You can define the subversion configuration directory (&apos;--config-dir&apos; svn global option) in the provider configuration file or with &apos;maven.scm.svn.config_directory&apos; command line parameter.
 
 ```
 mvn -Dmaven.scm.svn.config_directory=your_configuration_directory scm:update


### PR DESCRIPTION
Pages converted from APT with an older `doxia-converter` carry a backslash in front of
punctuation that is not markup where it stands, for example `maven\-source\-plugin`,
`\(default\)` and `required\.`. The backslash renders as nothing; it only makes the source
harder to read and to edit, which was the point of moving to Markdown.

Only positions where the bare character can never be markup are touched: a hyphen,
underscore or asterisk between two word characters, a parenthesis, a full stop that
does not follow a digit, and an exclamation mark not followed by `[`.

Left alone deliberately:

* angle brackets, since `<escapeString>` really would be read as an HTML tag
* a full stop after a digit, so an ordered list marker cannot appear by accident
* a run of dots, because bare `...` is rendered as a single ellipsis character
* code spans, fenced blocks and link destinations

Verified by building the site before and after: every generated page is identical in
its visible text and in every link target.